### PR TITLE
fix(structural): deterministic choice-type exclusivity (#59)

### DIFF
--- a/pkg/structural/structural.go
+++ b/pkg/structural/structural.go
@@ -141,11 +141,22 @@ func (v *Validator) ValidateData(data map[string]any, sd *registry.StructureDefi
 	return result
 }
 
-// matchChoiceType checks if a data key matches a choice type in the element index.
+// matchChoiceType checks if a data key matches a choice type defined as a
+// direct child of sdPath in the element index.
 // Returns the choice base path (e.g., "Observation.value") if matched, or empty string otherwise.
-func matchChoiceType(key, _ string, idx *elementIndex) string {
+//
+// Scoping to sdPath is required for determinism: a StructureDefinition can have
+// multiple choice types sharing the same baseName at different levels (e.g.
+// Observation.value[x] and Observation.component.value[x]). Without the scope,
+// the result depended on Go's randomized map iteration order, so choice-type
+// mutual-exclusion detection became non-deterministic (issue #59).
+func matchChoiceType(key, sdPath string, idx *elementIndex) string {
 	for choiceBasePath, choiceElemDef := range idx.choiceTypes {
 		choiceBaseName := choiceBasePath[strings.LastIndex(choiceBasePath, ".")+1:]
+		// Only consider choice types that are direct children of sdPath.
+		if choiceBasePath != sdPath+"."+choiceBaseName {
+			continue
+		}
 		if strings.HasPrefix(key, choiceBaseName) && len(key) > len(choiceBaseName) {
 			typeSuffix := key[len(choiceBaseName):]
 			if findMatchingChoiceType(choiceElemDef, typeSuffix) != "" {
@@ -327,10 +338,19 @@ func (v *Validator) resolveElementDefinition(
 	}
 
 	// 2. Try resolving as choice type
-	// Look for a choice type whose base matches the beginning of elementName
+	// Look for a choice type whose base matches the beginning of elementName.
+	// Scope to choice types defined as a direct child of elementPath's parent,
+	// so that baseName collisions across levels (e.g. Observation.value[x] vs
+	// Observation.component.value[x]) resolve deterministically (issue #59).
+	parentPath := elementPath[:strings.LastIndex(elementPath, ".")+1]
 	for choiceBasePath, choiceElemDef := range idx.choiceTypes {
 		// Get the element name from the choice path (e.g., "Patient.deceased" -> "deceased")
 		choiceBaseName := choiceBasePath[strings.LastIndex(choiceBasePath, ".")+1:]
+
+		// Only consider choice types that are direct children of the same parent.
+		if choiceBasePath != parentPath+choiceBaseName {
+			continue
+		}
 
 		// Check if element starts with the choice base name
 		if strings.HasPrefix(elementName, choiceBaseName) && len(elementName) > len(choiceBaseName) {

--- a/pkg/structural/structural_test.go
+++ b/pkg/structural/structural_test.go
@@ -1,9 +1,12 @@
 package structural
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
+	"github.com/gofhir/validator/pkg/issue"
 	"github.com/gofhir/validator/pkg/loader"
 	"github.com/gofhir/validator/pkg/registry"
 )
@@ -363,6 +366,115 @@ func TestValidateObservationChoiceTypes(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestValidateChoiceTypeExclusivityDeterministic reproduces issue #59:
+// matchChoiceType ignored the element-level scope, so on a resource with two
+// choice types sharing the same baseName at different levels (Observation
+// value[x] vs component.value[x]), the mutual-exclusion detection was
+// non-deterministic. Running the same validation many times must ALWAYS flag
+// the violation; before the fix, some iterations missed it due to Go's
+// randomized map iteration order.
+func TestValidateChoiceTypeExclusivityDeterministic(t *testing.T) {
+	reg := setupTestRegistry(t)
+	v := New(reg)
+
+	sd := reg.GetByURL("http://hl7.org/fhir/StructureDefinition/Observation")
+	if sd == nil {
+		t.Skip("Observation StructureDefinition not found")
+	}
+
+	// Two variants of value[x] present at the root -> must always be rejected.
+	resource := []byte(`{
+		"resourceType": "Observation",
+		"status": "final",
+		"code": {"text": "test"},
+		"valueQuantity": {"value": 42, "unit": "mg"},
+		"valueString": "forty-two"
+	}`)
+
+	const iterations = 500
+	for i := range iterations {
+		result := v.Validate(resource, sd)
+		if !hasMutualExclusionError(result) {
+			t.Fatalf("iteration %d: expected choice-type mutual-exclusion error, got none. Issues:\n%s",
+				i, formatIssues(result))
+		}
+	}
+}
+
+// TestValidateChoiceTypeComponentScope ensures a value[x] inside component is
+// resolved against component.value[x] and a single root value[x] is still
+// accepted (no false positive from cross-level baseName collisions).
+func TestValidateChoiceTypeComponentScope(t *testing.T) {
+	reg := setupTestRegistry(t)
+	v := New(reg)
+
+	sd := reg.GetByURL("http://hl7.org/fhir/StructureDefinition/Observation")
+	if sd == nil {
+		t.Skip("Observation StructureDefinition not found")
+	}
+
+	// Single value[x] at root AND a single value[x] inside a component: valid.
+	resource := []byte(`{
+		"resourceType": "Observation",
+		"status": "final",
+		"code": {"text": "test"},
+		"valueString": "positive",
+		"component": [
+			{
+				"code": {"text": "sub"},
+				"valueQuantity": {"value": 1, "unit": "mg"}
+			}
+		]
+	}`)
+
+	const iterations = 500
+	for i := range iterations {
+		result := v.Validate(resource, sd)
+		if hasMutualExclusionError(result) {
+			t.Fatalf("iteration %d: unexpected mutual-exclusion error for single value[x] per level. Issues:\n%s",
+				i, formatIssues(result))
+		}
+	}
+
+	// Two variants inside component -> must always be rejected.
+	bad := []byte(`{
+		"resourceType": "Observation",
+		"status": "final",
+		"code": {"text": "test"},
+		"component": [
+			{
+				"code": {"text": "sub"},
+				"valueQuantity": {"value": 1, "unit": "mg"},
+				"valueString": "one"
+			}
+		]
+	}`)
+	for i := range iterations {
+		result := v.Validate(bad, sd)
+		if !hasMutualExclusionError(result) {
+			t.Fatalf("iteration %d: expected mutual-exclusion error for two component value[x], got none. Issues:\n%s",
+				i, formatIssues(result))
+		}
+	}
+}
+
+func hasMutualExclusionError(result *issue.Result) bool {
+	for _, iss := range result.Issues {
+		if iss.MessageID == string(issue.DiagStructureChoiceMutualExclusion) {
+			return true
+		}
+	}
+	return false
+}
+
+func formatIssues(result *issue.Result) string {
+	var b strings.Builder
+	for _, iss := range result.Issues {
+		fmt.Fprintf(&b, "  - [%s] %s @ %v\n", iss.Severity, iss.Diagnostics, iss.Expression)
+	}
+	return b.String()
 }
 
 func TestValidateBundleEntryResource(t *testing.T) {


### PR DESCRIPTION
## Resumen

Corrige el issue #59: la validación de exclusividad de choice-type (FHIR R4 §2.6.2) era **no determinista**. Para un mismo recurso con dos variantes de `value[x]`, a veces se detectaba la violación y a veces no, según el orden de iteración de maps en Go.

## Causa raíz

`matchChoiceType` descartaba el parámetro `sdPath` y escaneaba **todos** los choice types del índice por `baseName`, devolviendo el primer hit del map. `Observation` tiene dos choice types con `baseName == "value"`:

- `Observation.value[x]`
- `Observation.component.value[x]`

Como ambos aceptan `Quantity`/`String` y el `for ... range` sobre el map no tiene orden estable, `valueQuantity` y `valueString` podían resolver a base paths distintos → el pre-scan los contaba por separado → falso negativo intermitente.

## Fix

Scope por nivel del elemento en ambas funciones, eliminando la dependencia del orden de iteración:

- `matchChoiceType`: usa `sdPath` (antes `_`) y solo considera choice types hijos directos (`choiceBasePath == sdPath + "." + choiceBaseName`).
- `resolveElementDefinition`: mismo scope derivando el `parentPath` del `elementPath` (misma raíz de ambigüedad, fuente latente de no determinismo).

Como las keys del map son únicas, dentro de un mismo nivel no puede haber dos choice types con el mismo `baseName` → detección determinista.

## Tests

Regression tests con 500 iteraciones (TDD — fallaban antes del fix):

- `TestValidateChoiceTypeExclusivityDeterministic`: dos `value[x]` en root → siempre rechazado.
- `TestValidateChoiceTypeComponentScope`: `value[x]` en root y component por separado válidos (sin falso positivo); dos variantes dentro de `component` → siempre rechazado.

## Verificación

- `go test ./...` completo pasa
- `go build ./...` y `go vet` limpios

Closes #59