### PR TITLE
feat: unify extension binding validation, consume Supports and CodeResult.Message

### DIFF
--- a/pkg/binding/binding.go
+++ b/pkg/binding/binding.go
@@ -55,14 +55,25 @@ func (v *Validator) SetDisplayLanguage(lang string) {
 	v.displayLanguage = lang
 }
 
+// detailSuffix renders a backend diagnostic for appending to a message. The
+// terminology port lets a backend explain its verdict — a retired code, an edition
+// mismatch — and dropping that would discard the most useful part of the answer.
+// Formatted here rather than in the template so an absent message leaves no trace.
+func detailSuffix(message string) string {
+	if message == "" {
+		return ""
+	}
+	return ": " + message
+}
+
 // reportUnresolved records a binding that could not be checked, at the severity
 // the configured policy asks for. Only required and extensible bindings reach
 // here, so a weaker binding never produces noise.
-func (v *Validator) reportUnresolved(code, valueSet, strength, fhirPath string, result *issue.Result) {
+func (v *Validator) reportUnresolved(code, valueSet, strength, detail, fhirPath string, result *issue.Result) {
 	if strength != strengthRequired && strength != strengthExtensible {
 		return
 	}
-	args := map[string]any{"code": code, "valueSet": valueSet}
+	args := map[string]any{"code": code, "valueSet": valueSet, "detail": detailSuffix(detail)}
 	if v.unresolvedPolicy == terminology.UnresolvedError {
 		result.AddErrorWithID(issue.DiagBindingUnresolved, args, fhirPath)
 		return
@@ -317,7 +328,7 @@ func (v *Validator) validateCodeableConceptWithCoding(ctx context.Context, val m
 	// Nothing could be decided for any coding: the binding is unresolvable, which
 	// is not the same as "none of the codings are members".
 	if !anyDecided && len(codeLabels) > 0 {
-		v.reportUnresolved(strings.Join(codeLabels, ", "), binding.ValueSet, binding.Strength, fhirPath, result)
+		v.reportUnresolved(strings.Join(codeLabels, ", "), binding.ValueSet, binding.Strength, "", fhirPath, result)
 		return
 	}
 
@@ -368,7 +379,7 @@ func (v *Validator) validateCodingInCC(ctx context.Context, coding map[string]an
 	if res.Resolution == terminology.Invalid {
 		// Only emit per-coding error for required bindings; extensible is deferred to CC level.
 		if binding.Strength == strengthRequired {
-			v.reportBindingViolation(system, code, res.SystemInValueSet, binding, fhirPath, result)
+			v.reportBindingViolation(system, code, res, binding, fhirPath, result)
 		}
 		return terminology.Invalid
 	}
@@ -449,12 +460,12 @@ func (v *Validator) validateCodeBinding(ctx context.Context, code, system string
 		// Undecidable: neither the local copies nor any configured backend could
 		// answer. Whether that is acceptable is a policy decision, not something
 		// this function gets to assume.
-		v.reportUnresolved(code, binding.ValueSet, binding.Strength, fhirPath, result)
+		v.reportUnresolved(code, binding.ValueSet, binding.Strength, res.Message, fhirPath, result)
 		return
 	}
 
 	if res.Resolution == terminology.Invalid {
-		v.reportBindingViolation(system, code, res.SystemInValueSet, binding, fhirPath, result)
+		v.reportBindingViolation(system, code, res, binding, fhirPath, result)
 	}
 }
 
@@ -483,12 +494,12 @@ func (v *Validator) validateCodingBinding(ctx context.Context, coding map[string
 		if system != "" {
 			codeDisplay = fmt.Sprintf("%s#%s", system, code)
 		}
-		v.reportUnresolved(codeDisplay, binding.ValueSet, binding.Strength, fhirPath, result)
+		v.reportUnresolved(codeDisplay, binding.ValueSet, binding.Strength, res.Message, fhirPath, result)
 		return
 	}
 
 	if res.Resolution == terminology.Invalid {
-		v.reportBindingViolation(system, code, res.SystemInValueSet, binding, fhirPath, result)
+		v.reportBindingViolation(system, code, res, binding, fhirPath, result)
 		return
 	}
 
@@ -590,12 +601,17 @@ func (v *Validator) validateDisplayMismatch(ctx context.Context, system, systemV
 // of whether the ValueSet declares the code's system, and the spec conditions
 // extensible conformance on whether the ValueSet covers the concept — a judgment
 // — not on whether the system is declared.
-func (v *Validator) reportBindingViolation(system, code string, membership terminology.Membership, binding *registry.Binding, fhirPath string, result *issue.Result) {
+func (v *Validator) reportBindingViolation(system, code string, res terminology.CodeResult, binding *registry.Binding, fhirPath string, result *issue.Result) {
 	codeDisplay := code
 	if system != "" {
 		codeDisplay = fmt.Sprintf("%s#%s", system, code)
 	}
-	args := map[string]any{"code": codeDisplay, "valueSet": binding.ValueSet}
+	args := map[string]any{
+		"code":     codeDisplay,
+		"valueSet": binding.ValueSet,
+		"detail":   detailSuffix(res.Message),
+	}
+	membership := res.SystemInValueSet
 
 	switch binding.Strength {
 	case strengthRequired:

--- a/pkg/binding/binding.go
+++ b/pkg/binding/binding.go
@@ -230,7 +230,18 @@ func (v *Validator) validateComplexElement(ctx context.Context, data map[string]
 
 // validateBinding validates a value against its binding.
 func (v *Validator) validateBinding(ctx context.Context, value any, elemDef *registry.ElementDefinition, fhirPath string, result *issue.Result) {
-	binding := elemDef.Binding
+	v.ValidateValueBinding(ctx, value, elemDef.Binding, fhirPath, result)
+}
+
+// ValidateValueBinding validates a value against an element binding.
+//
+// Exported for callers that hold the binding without an ElementDefinition — chiefly
+// extension validation, where the binding comes from the extension's own
+// StructureDefinition. Routing both traversals through here is what keeps them from
+// drifting: display checks, CodeSystem membership, CodeableConcept aggregation, the
+// unresolved policy and the extensible severity table apply the same way to an
+// extension value as to any other element.
+func (v *Validator) ValidateValueBinding(ctx context.Context, value any, binding *registry.Binding, fhirPath string, result *issue.Result) {
 	if binding == nil {
 		return
 	}
@@ -252,7 +263,7 @@ func (v *Validator) validateBinding(ctx context.Context, value any, elemDef *reg
 	case []any:
 		for i, item := range val {
 			itemPath := fmt.Sprintf("%s[%d]", fhirPath, i)
-			v.validateBinding(ctx, item, elemDef, itemPath, result)
+			v.ValidateValueBinding(ctx, item, binding, itemPath, result)
 		}
 	}
 }

--- a/pkg/extension/extension.go
+++ b/pkg/extension/extension.go
@@ -31,7 +31,15 @@ type Validator struct {
 	registry      *registry.Registry
 	walker        *walker.Walker
 	termRegistry  *terminology.Registry
+	bindValidator BindingValidator
 	primValidator *primitive.Validator
+}
+
+// BindingValidator validates a value against an element binding. Implemented by
+// *binding.Validator; an interface here so this package does not depend on the
+// concrete type, and so terminology-free callers can leave it unset.
+type BindingValidator interface {
+	ValidateValueBinding(ctx context.Context, value any, binding *registry.Binding, fhirPath string, result *issue.Result)
 }
 
 // New creates a new extension Validator.
@@ -42,6 +50,12 @@ func New(reg *registry.Registry, termReg *terminology.Registry, primVal *primiti
 		termRegistry:  termReg,
 		primValidator: primVal,
 	}
+}
+
+// SetBindingValidator supplies the validator used for bindings on extension
+// values, so extension values are checked by the same code as any other element.
+func (v *Validator) SetBindingValidator(b BindingValidator) {
+	v.bindValidator = b
 }
 
 // Validate validates all extensions in a resource.
@@ -945,184 +959,14 @@ func (v *Validator) validateNestedExtensionValue(ext map[string]any, valueDef *r
 
 // validateExtensionBinding validates the binding on an extension's value[x].
 func (v *Validator) validateExtensionBinding(ctx context.Context, value any, binding *registry.Binding, valuePath string, result *issue.Result) {
-	if v.termRegistry == nil {
-		return // No terminology registry available
+	if v.bindValidator == nil {
+		return // binding validation not wired
 	}
-
-	// Only validate required and extensible bindings
-	if binding.Strength != strengthRequired && binding.Strength != strengthExtensible {
-		return
-	}
-
-	switch val := value.(type) {
-	case string:
-		// Simple code value (e.g., valueCode)
-		v.validateCodeBinding(ctx, val, "", binding, valuePath, result)
-
-	case map[string]any:
-		// Could be Coding, CodeableConcept, or other complex type
-		v.validateMapBinding(ctx, val, binding, valuePath, result)
-	}
-}
-
-// validateCodeBinding validates a code against a ValueSet binding.
-func (v *Validator) validateCodeBinding(ctx context.Context, code, system string, binding *registry.Binding, fhirPath string, result *issue.Result) {
-	if code == "" {
-		return
-	}
-
-	// Check if system is external (requires terminology server)
-	if system != "" && v.termRegistry.IsExternalSystem(system) {
-		result.AddInfoWithID(
-			issue.DiagBindingCannotValidate,
-			map[string]any{
-				"code":   code,
-				"system": system,
-			},
-			fhirPath,
-		)
-		return // Accept code from external system with info message
-	}
-
-	valid, found := v.termRegistry.ValidateCodeContext(ctx, binding.ValueSet, system, code)
-	if !found {
-		// ValueSet not found - emit warning
-		result.AddWarningWithID(
-			issue.DiagBindingValueSetNotFound,
-			map[string]any{
-				"valueSet": binding.ValueSet,
-				"code":     code,
-			},
-			fhirPath,
-		)
-		return
-	}
-
-	if !valid {
-		switch binding.Strength {
-		case "required":
-			result.AddErrorWithID(
-				issue.DiagBindingRequired,
-				map[string]any{
-					"code":     code,
-					"valueSet": binding.ValueSet,
-				},
-				fhirPath,
-			)
-		case "extensible":
-			result.AddWarningWithID(
-				issue.DiagBindingExtensible,
-				map[string]any{
-					"code":     code,
-					"valueSet": binding.ValueSet,
-				},
-				fhirPath,
-			)
-		}
-	}
-}
-
-// validateMapBinding validates a map value (Coding or CodeableConcept) against a binding.
-func (v *Validator) validateMapBinding(ctx context.Context, val map[string]any, binding *registry.Binding, fhirPath string, result *issue.Result) {
-	// Check if it's a CodeableConcept with coding array
-	if coding, ok := val["coding"]; ok {
-		codings, isList := coding.([]any)
-		if isList {
-			for i, c := range codings {
-				if codingMap, ok := c.(map[string]any); ok {
-					codingPath := fmt.Sprintf("%s.coding[%d]", fhirPath, i)
-					v.validateCodingBinding(ctx, codingMap, binding, codingPath, result)
-				}
-			}
-		}
-		return
-	}
-
-	// Looks like a Coding with system/code
-	if _, ok := val["system"]; ok {
-		v.validateCodingBinding(ctx, val, binding, fhirPath, result)
-		return
-	}
-
-	// Coding with just code
-	if code, ok := val["code"]; ok {
-		if codeStr, ok := code.(string); ok {
-			v.validateCodeBinding(ctx, codeStr, "", binding, fhirPath, result)
-		}
-	}
-}
-
-// validateCodingBinding validates a Coding against a ValueSet binding.
-func (v *Validator) validateCodingBinding(ctx context.Context, coding map[string]any, binding *registry.Binding, fhirPath string, result *issue.Result) {
-	system, _ := coding["system"].(string)
-	code, _ := coding["code"].(string)
-
-	if code == "" {
-		return
-	}
-
-	// Check if system is external (requires terminology server)
-	if system != "" && v.termRegistry.IsExternalSystem(system) {
-		result.AddInfoWithID(
-			issue.DiagBindingCannotValidate,
-			map[string]any{
-				"code":   code,
-				"system": system,
-			},
-			fhirPath,
-		)
-		return // Accept code from external system with info message
-	}
-
-	valid, found := v.termRegistry.ValidateCodeContext(ctx, binding.ValueSet, system, code)
-	if !found {
-		// ValueSet not found - emit warning
-		codeDisplay := code
-		if system != "" {
-			codeDisplay = fmt.Sprintf("%s#%s", system, code)
-		}
-		result.AddWarningWithID(
-			issue.DiagBindingValueSetNotFound,
-			map[string]any{
-				"valueSet": binding.ValueSet,
-				"code":     codeDisplay,
-			},
-			fhirPath,
-		)
-		return
-	}
-
-	if !valid {
-		codeDisplay := code
-		if system != "" {
-			codeDisplay = fmt.Sprintf("%s#%s", system, code)
-		}
-
-		switch binding.Strength {
-		case "required":
-			result.AddErrorWithID(
-				issue.DiagBindingRequired,
-				map[string]any{
-					"code":     codeDisplay,
-					"valueSet": binding.ValueSet,
-				},
-				fhirPath,
-			)
-		case "extensible":
-			// For extensible bindings, only warn if the system IS in the ValueSet.
-			// If the system is NOT in the ValueSet, the code is "extending" the binding
-			// (using a different code system), which is allowed without warning.
-			if system == "" || v.termRegistry.IsSystemInValueSet(binding.ValueSet, system) {
-				result.AddWarningWithID(
-					issue.DiagBindingExtensible,
-					map[string]any{
-						"code":     codeDisplay,
-						"valueSet": binding.ValueSet,
-					},
-					fhirPath,
-				)
-			}
-			// If system is not in ValueSet, no warning - code is extending the binding
-		}
-	}
+	// Delegated rather than reimplemented. This path used to have its own copy of
+	// the logic, which is how it fell behind: it never checked Coding.display or
+	// whether a code exists in its own CodeSystem, reported one issue per coding
+	// instead of aggregating a CodeableConcept, and treated an unresolvable binding
+	// as nothing at all. An extension value is bound like any other element and is
+	// now validated like one.
+	v.bindValidator.ValidateValueBinding(ctx, value, binding, valuePath, result)
 }

--- a/pkg/issue/diagnostics.go
+++ b/pkg/issue/diagnostics.go
@@ -219,12 +219,12 @@ var diagnosticTemplates = map[DiagnosticID]DiagnosticTemplate{
 	DiagBindingRequired: {
 		Severity: SeverityError,
 		Code:     CodeCodeInvalid,
-		Template: "The value provided ('{code}') is not in the value set '{valueSet}' (required)",
+		Template: "The value provided ('{code}') is not in the value set '{valueSet}' (required){detail}",
 	},
 	DiagBindingExtensible: {
 		Severity: SeverityWarning,
 		Code:     CodeCodeInvalid,
-		Template: "The value provided ('{code}') is not in the value set '{valueSet}' (extensible)",
+		Template: "The value provided ('{code}') is not in the value set '{valueSet}' (extensible){detail}",
 	},
 	// The code's system is not among those the ValueSet declares, which is the
 	// case extensible bindings exist to permit. Informational rather than a
@@ -232,14 +232,14 @@ var diagnosticTemplates = map[DiagnosticID]DiagnosticTemplate{
 	DiagBindingExtensibleOther: {
 		Severity: SeverityInformation,
 		Code:     CodeInformational,
-		Template: "The value provided ('{code}') is not in the value set '{valueSet}', and comes from a system the value set does not declare (extensible bindings permit this)",
+		Template: "The value provided ('{code}') is not in the value set '{valueSet}', and comes from a system the value set does not declare (extensible bindings permit this){detail}",
 	},
 	// Membership could not be established, so neither acceptance nor rejection
 	// can be justified; reported at the same severity as a plain extensible miss.
 	DiagBindingExtensibleUnknown: {
 		Severity: SeverityWarning,
 		Code:     CodeCodeInvalid,
-		Template: "The value provided ('{code}') is not in the value set '{valueSet}' (extensible); whether its system belongs to the value set could not be determined",
+		Template: "The value provided ('{code}') is not in the value set '{valueSet}' (extensible); whether its system belongs to the value set could not be determined{detail}",
 	},
 	DiagBindingDisplayMismatch: {
 		Severity: SeverityError,
@@ -257,7 +257,7 @@ var diagnosticTemplates = map[DiagnosticID]DiagnosticTemplate{
 	DiagBindingUnresolved: {
 		Severity: SeverityError,
 		Code:     CodeCodeInvalid,
-		Template: "The value provided ('{code}') could not be checked against value set '{valueSet}': no terminology source could resolve it",
+		Template: "The value provided ('{code}') could not be checked against value set '{valueSet}': no terminology source could resolve it{detail}",
 	},
 	DiagBindingCannotValidate: {
 		Severity: SeverityInformation,

--- a/pkg/terminology/negative_cache_test.go
+++ b/pkg/terminology/negative_cache_test.go
@@ -173,3 +173,67 @@ func TestUnresolvedCacheIsPerCanonical(t *testing.T) {
 		t.Errorf("authority called %d times, want 2 (one per distinct canonical)", a.calls.Load())
 	}
 }
+
+// unsupportingAuthority declines every canonical through Supports, which is how a
+// chain with no terminology server configured answers.
+type unsupportingAuthority struct{ resolveCalls atomic.Int64 }
+
+func (a *unsupportingAuthority) ResolveCodeInValueSet(context.Context, string, string, string, LookupOptions) (CodeResult, error) {
+	a.resolveCalls.Add(1)
+	return CodeResult{Resolution: Unresolved}, nil
+}
+
+func (a *unsupportingAuthority) ResolveCodeInCodeSystem(context.Context, string, string, LookupOptions) (CodeResult, error) {
+	return CodeResult{Resolution: Unresolved}, nil
+}
+
+func (a *unsupportingAuthority) Supports(context.Context, string) bool { return false }
+
+// TestSupportsShortCircuitsTheLookup covers the hint the contract promises: when the
+// authority says nothing in its chain can decide a canonical, asking anyway would
+// spend a round-trip to learn what it already said.
+func TestSupportsShortCircuitsTheLookup(t *testing.T) {
+	r := NewRegistry()
+	a := &unsupportingAuthority{}
+	r.SetAuthority(a)
+
+	res, err := r.ResolveCodeInValueSet(context.Background(), "sys", "code", missingVS, LookupOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Resolution != Unresolved {
+		t.Errorf("Resolution = %v, want %v", res.Resolution, Unresolved)
+	}
+	if a.resolveCalls.Load() != 0 {
+		t.Errorf("the resolve call was made %d times despite Supports being false",
+			a.resolveCalls.Load())
+	}
+}
+
+// TestBackendMessageReachesTheDiagnostic keeps CodeResult.Message from being
+// discarded: a backend that explains its verdict — a retired code, an edition
+// mismatch — is saying the most useful part of the answer.
+func TestBackendMessageReachesTheDiagnostic(t *testing.T) {
+	r := NewRegistry()
+	r.SetAuthority(&messagingAuthority{message: "code was retired in the 2024 edition"})
+
+	res, err := r.ResolveCodeInValueSet(context.Background(), "sys", "code", missingVS, LookupOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Message != "code was retired in the 2024 edition" {
+		t.Errorf("Message = %q, want the backend's explanation", res.Message)
+	}
+}
+
+type messagingAuthority struct{ message string }
+
+func (a *messagingAuthority) ResolveCodeInValueSet(context.Context, string, string, string, LookupOptions) (CodeResult, error) {
+	return CodeResult{Resolution: Invalid, Message: a.message}, nil
+}
+
+func (a *messagingAuthority) ResolveCodeInCodeSystem(context.Context, string, string, LookupOptions) (CodeResult, error) {
+	return CodeResult{Resolution: Invalid, Message: a.message}, nil
+}
+
+func (a *messagingAuthority) Supports(context.Context, string) bool { return true }

--- a/pkg/terminology/terminology.go
+++ b/pkg/terminology/terminology.go
@@ -415,6 +415,15 @@ func (r *Registry) ResolveCodeInValueSet(ctx context.Context, system, code, valu
 			return CodeResult{Resolution: Unresolved}, nil
 		}
 
+		// Supports is the authority's own short-circuit: false means nothing in its
+		// chain could decide this canonical, so asking would spend a round-trip to
+		// learn what it already told us. Remembered like any other unresolvable
+		// answer.
+		if !a.Supports(ctx, valueSetURL) {
+			r.markUnresolved(valueSetURL)
+			return CodeResult{Resolution: Unresolved}, nil
+		}
+
 		res, err := a.ResolveCodeInValueSet(ctx, system, code, valueSetURL, opts)
 		if err == nil && res.Resolution == Unresolved {
 			r.markUnresolved(valueSetURL)

--- a/pkg/validator/binding_severity_test.go
+++ b/pkg/validator/binding_severity_test.go
@@ -14,14 +14,38 @@ import (
 type membershipAuthority struct {
 	resolution terminology.Resolution
 	membership terminology.Membership
-	calls      int
+	message    string
+	display    string
+	// displayLanguageHonored is what the authority claims about Display; false makes
+	// callers skip display comparison.
+	displayLanguageHonored bool
+	calls                  int
 }
 
 // set retargets the verdict so one validator can drive every row of the table.
 func (a *membershipAuthority) set(res terminology.Resolution, m terminology.Membership) {
 	a.resolution = res
 	a.membership = m
+	a.message = ""
+	a.display = ""
+	a.displayLanguageHonored = true
 	a.calls = 0
+}
+
+// setMessage attaches a backend explanation to the verdict.
+func (a *membershipAuthority) setMessage(msg string) { a.message = msg }
+
+// setDisplay makes the authority report a display, for display-mismatch checks.
+func (a *membershipAuthority) setDisplay(d string) {
+	a.display = d
+	a.displayLanguageHonored = true
+}
+
+// setUnhonoredDisplay reports a display that is not in the requested language, which
+// must make callers skip the comparison rather than compare against a fallback.
+func (a *membershipAuthority) setUnhonoredDisplay(d string) {
+	a.display = d
+	a.displayLanguageHonored = false
 }
 
 // authorityFixture is built once for the whole package. Every New() reloads the
@@ -35,9 +59,76 @@ type authorityFixture struct {
 
 var sharedAuthorityFixture = sync.OnceValue(func() authorityFixture {
 	auth := &membershipAuthority{}
-	v, err := New(WithVersion("4.0.1"), WithTerminologyAuthority(auth))
+	v, err := New(
+		WithVersion("4.0.1"),
+		WithTerminologyAuthority(auth),
+		// Carried by the shared fixture so extension-binding tests need no validator
+		// of their own: boundExtensionSD is inert unless a resource uses it.
+		WithConformanceResources([][]byte{[]byte(boundExtensionSD)}),
+		// UnresolvedError so the policy is observable here. It changes nothing for
+		// tests whose authority returns a decided verdict.
+		WithUnresolvedPolicy(UnresolvedError),
+	)
+	if err == nil {
+		// Subtests retarget the shared authority, and the negative cache would
+		// correctly refuse to ask again for a canonical a previous subtest reported
+		// unresolvable — answering the next one from the cache instead. Disabled here
+		// so sharing a validator does not leak state between subtests; the cache has
+		// its own tests in pkg/terminology.
+		v.TerminologyRegistry().SetUnresolvedCacheTTL(0)
+	}
 	return authorityFixture{v: v, auth: auth, err: err}
 })
+
+// warnFixture is the same, with the default unresolved policy, for tests that assert
+// the accepting behavior.
+var warnFixture = sync.OnceValue(func() authorityFixture {
+	auth := &membershipAuthority{}
+	v, err := New(
+		WithVersion("4.0.1"),
+		WithTerminologyAuthority(auth),
+		WithConformanceResources([][]byte{[]byte(boundExtensionSD)}),
+	)
+	if err == nil {
+		v.TerminologyRegistry().SetUnresolvedCacheTTL(0)
+	}
+	return authorityFixture{v: v, auth: auth, err: err}
+})
+
+// spanishFixture requests Spanish displays, for the i18n checks. Its authority is
+// separate because DisplayLanguage is set at construction.
+var spanishFixture = sync.OnceValue(func() authorityFixture {
+	auth := &membershipAuthority{}
+	v, err := New(
+		WithVersion("4.0.1"),
+		WithTerminologyAuthority(auth),
+		WithDisplayLanguage("es"),
+	)
+	if err == nil {
+		v.TerminologyRegistry().SetUnresolvedCacheTTL(0)
+	}
+	return authorityFixture{v: v, auth: auth, err: err}
+})
+
+// warnValidator returns the shared validator built with the default policy.
+func warnValidator(t *testing.T) (*Validator, *membershipAuthority) {
+	t.Helper()
+	f := warnFixture()
+	if f.err != nil {
+		t.Fatalf("New: %v", f.err)
+	}
+	return f.v, f.auth
+}
+
+// spanishValidator returns the shared validator that requests Spanish displays.
+func spanishValidator(t *testing.T) (*Validator, *membershipAuthority) {
+	t.Helper()
+	f := spanishFixture()
+	if f.err != nil {
+		t.Fatalf("New: %v", f.err)
+	}
+	return f.v, f.auth
+}
 
 // authorityValidator returns the shared validator and its mutable authority.
 // Callers must not run in parallel: they retarget shared state.
@@ -53,15 +144,23 @@ func authorityValidator(t *testing.T) (*Validator, *membershipAuthority) {
 func (a *membershipAuthority) ResolveCodeInValueSet(_ context.Context, _, _, _ string, _ terminology.LookupOptions) (terminology.CodeResult, error) {
 	a.calls++
 	return terminology.CodeResult{
-		Resolution:       a.resolution,
-		SystemInValueSet: a.membership,
+		Resolution:             a.resolution,
+		SystemInValueSet:       a.membership,
+		Message:                a.message,
+		Display:                a.display,
+		DisplayLanguageHonored: a.displayLanguageHonored,
 	}, nil
 }
 
 func (a *membershipAuthority) ResolveCodeInCodeSystem(_ context.Context, _, _ string, _ terminology.LookupOptions) (terminology.CodeResult, error) {
 	a.calls++
 	// Codes exist in their CodeSystem; only ValueSet membership is under test.
-	return terminology.CodeResult{Resolution: terminology.Valid}, nil
+	return terminology.CodeResult{
+		Resolution:             terminology.Valid,
+		Display:                a.display,
+		DisplayLanguageHonored: a.displayLanguageHonored,
+		Message:                a.message,
+	}, nil
 }
 
 func (a *membershipAuthority) Supports(context.Context, string) bool { return true }

--- a/pkg/validator/display_language_test.go
+++ b/pkg/validator/display_language_test.go
@@ -8,44 +8,6 @@ import (
 	"github.com/gofhir/validator/pkg/terminology"
 )
 
-// localizingAuthority answers with a display in the requested language when it has
-// one, mirroring a host whose store carries designations.
-type localizingAuthority struct {
-	displays map[string]string // BCP-47 tag -> display; "" is the default
-}
-
-func (a *localizingAuthority) ResolveCodeInValueSet(_ context.Context, _, _, _ string, opts terminology.LookupOptions) (terminology.CodeResult, error) {
-	display, honored := a.pick(opts.DisplayLanguage)
-	return terminology.CodeResult{
-		Resolution:             terminology.Valid,
-		Display:                display,
-		DisplayLanguageHonored: honored,
-		SystemInValueSet:       terminology.MembershipIncluded,
-	}, nil
-}
-
-func (a *localizingAuthority) ResolveCodeInCodeSystem(_ context.Context, _, _ string, opts terminology.LookupOptions) (terminology.CodeResult, error) {
-	display, honored := a.pick(opts.DisplayLanguage)
-	return terminology.CodeResult{
-		Resolution:             terminology.Valid,
-		Display:                display,
-		DisplayLanguageHonored: honored,
-	}, nil
-}
-
-func (a *localizingAuthority) pick(lang string) (display string, honored bool) {
-	if lang == "" {
-		return a.displays[""], true
-	}
-	if d, ok := a.displays[lang]; ok {
-		return d, true
-	}
-	// No designation in that language: return the default and say so.
-	return a.displays[""], false
-}
-
-func (a *localizingAuthority) Supports(context.Context, string) bool { return true }
-
 // A Coding whose display is the valid Spanish translation of the concept.
 const spanishDisplayResource = `{
   "resourceType": "Encounter",
@@ -57,125 +19,93 @@ const spanishDisplayResource = `{
   }
 }`
 
-// TestSpanishDisplayIsNotRejectedWhenLanguageIsHonored is the case that motivated
-// this work: a valid non-English display must not be reported as a mismatch.
-func TestSpanishDisplayIsNotRejectedWhenLanguageIsHonored(t *testing.T) {
-	auth := &localizingAuthority{displays: map[string]string{
-		"":   "ambulatory",
-		"es": "ambulatorio",
-	}}
-	v, err := New(
-		WithVersion("4.0.1"),
-		WithTerminologyAuthority(auth),
-		WithDisplayLanguage("es"),
-	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-
-	result, err := v.Validate(context.Background(), []byte(spanishDisplayResource))
-	if err != nil {
-		t.Fatalf("Validate: %v", err)
-	}
-
-	if got := issueFor(t, result, issue.DiagBindingDisplayMismatch); got != nil {
-		t.Errorf("a valid Spanish display must not be a mismatch: %s", got.Diagnostics)
-	}
-}
-
-// TestDisplayCheckIsSkippedWhenLanguageCannotBeHonored covers the decoupling that
-// lets this ship before a host carries designations: rather than compare a
-// submitted translation against English, the check is skipped.
-func TestDisplayCheckIsSkippedWhenLanguageCannotBeHonored(t *testing.T) {
-	// The authority has only the default display — no Spanish designation yet.
-	auth := &localizingAuthority{displays: map[string]string{"": "ambulatory"}}
-	v, err := New(
-		WithVersion("4.0.1"),
-		WithTerminologyAuthority(auth),
-		WithDisplayLanguage("es"),
-	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-
-	result, err := v.Validate(context.Background(), []byte(spanishDisplayResource))
-	if err != nil {
-		t.Fatalf("Validate: %v", err)
-	}
-
-	if got := issueFor(t, result, issue.DiagBindingDisplayMismatch); got != nil {
-		t.Errorf("with the language unhonored there is nothing to compare against, "+
-			"so no mismatch should be reported: %s", got.Diagnostics)
-	}
-}
-
-// TestWrongDisplayIsStillAnError guards the other direction: the i18n handling
-// must not become a blanket excuse to skip display validation.
-func TestWrongDisplayIsStillAnError(t *testing.T) {
-	auth := &localizingAuthority{displays: map[string]string{
-		"":   "ambulatory",
-		"es": "ambulatorio",
-	}}
-	v, err := New(
-		WithVersion("4.0.1"),
-		WithTerminologyAuthority(auth),
-		WithDisplayLanguage("es"),
-	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-
-	wrong := []byte(`{
+func encounterWithDisplay(display string) []byte {
+	return []byte(`{
 	  "resourceType": "Encounter",
 	  "status": "finished",
 	  "class": {
 	    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
 	    "code": "AMB",
-	    "display": "hospitalizado"
+	    "display": "` + display + `"
 	  }
 	}`)
-
-	result, err := v.Validate(context.Background(), wrong)
-	if err != nil {
-		t.Fatalf("Validate: %v", err)
-	}
-
-	got := issueFor(t, result, issue.DiagBindingDisplayMismatch)
-	if got == nil {
-		t.Fatalf("a genuinely wrong display must still be reported; issues: %v", result.Issues)
-	}
-	// Error, not warning: per HL7's guidance a wrong display often means the wrong
-	// code was chosen.
-	if got.Severity != issue.SeverityError {
-		t.Errorf("severity = %s, want %s", got.Severity, issue.SeverityError)
-	}
 }
 
-// TestDisplayValidationWithoutLanguagePreference checks the default path, where no
-// language is requested and the concept's default display is authoritative.
-func TestDisplayValidationWithoutLanguagePreference(t *testing.T) {
-	auth := &localizingAuthority{displays: map[string]string{"": "ambulatory"}}
-	v, err := New(WithVersion("4.0.1"), WithTerminologyAuthority(auth))
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+// TestDisplayValidationIsLanguageAware covers the case that motivated the work: a
+// display in another language used to be compared against the English one and
+// rejected, which is a validator bug rather than a data problem.
+//
+// Subtests share one validator built with WithDisplayLanguage("es"), because each
+// New() reloads the full package set.
+func TestDisplayValidationIsLanguageAware(t *testing.T) {
+	v, auth := spanishValidator(t)
+	ctx := context.Background()
 
-	matching := []byte(`{
-	  "resourceType": "Encounter",
-	  "status": "finished",
-	  "class": {
-	    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-	    "code": "AMB",
-	    "display": "Ambulatory"
-	  }
-	}`)
+	t.Run("valid translation is accepted", func(t *testing.T) {
+		auth.set(terminology.Valid, terminology.MembershipIncluded)
+		auth.setDisplay("ambulatorio") // honored: the backend has the Spanish designation
 
-	result, err := v.Validate(context.Background(), matching)
+		result, err := v.Validate(ctx, []byte(spanishDisplayResource))
+		if err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+		if got := issueFor(t, result, issue.DiagBindingDisplayMismatch); got != nil {
+			t.Errorf("a valid Spanish display must not be a mismatch: %s", got.Diagnostics)
+		}
+	})
+
+	t.Run("skipped when the language cannot be honored", func(t *testing.T) {
+		// This is the decoupling designed into the contract: a host can ship display
+		// validation before its store carries designations without a single false
+		// rejection, because an unhonored language skips the comparison instead of
+		// checking a translation against English.
+		auth.set(terminology.Valid, terminology.MembershipIncluded)
+		auth.setUnhonoredDisplay("ambulatory")
+
+		result, err := v.Validate(ctx, []byte(spanishDisplayResource))
+		if err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+		if got := issueFor(t, result, issue.DiagBindingDisplayMismatch); got != nil {
+			t.Errorf("with the language unhonored there is nothing to compare against: %s",
+				got.Diagnostics)
+		}
+	})
+
+	t.Run("a wrong display is still an error", func(t *testing.T) {
+		// The i18n handling must not become a blanket excuse to skip the check.
+		// Error rather than warning, per HL7's guidance: a wrong display often means
+		// the wrong code was chosen.
+		auth.set(terminology.Valid, terminology.MembershipIncluded)
+		auth.setDisplay("ambulatorio")
+
+		result, err := v.Validate(ctx, encounterWithDisplay("hospitalizado"))
+		if err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+		got := issueFor(t, result, issue.DiagBindingDisplayMismatch)
+		if got == nil {
+			t.Fatalf("a genuinely wrong display must still be reported; issues: %v",
+				result.Issues)
+		}
+		if got.Severity != issue.SeverityError {
+			t.Errorf("severity = %s, want %s", got.Severity, issue.SeverityError)
+		}
+	})
+}
+
+// TestDisplayComparisonIsCaseInsensitive uses the fixture with no language
+// preference, where the concept's default display is authoritative.
+func TestDisplayComparisonIsCaseInsensitive(t *testing.T) {
+	v, auth := warnValidator(t)
+	auth.set(terminology.Valid, terminology.MembershipIncluded)
+	auth.setDisplay("ambulatory")
+
+	result, err := v.Validate(context.Background(), encounterWithDisplay("Ambulatory"))
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
-	// Case-insensitive, per HL7.
 	if got := issueFor(t, result, issue.DiagBindingDisplayMismatch); got != nil {
-		t.Errorf("display comparison is case-insensitive: %s", got.Diagnostics)
+		t.Errorf("display comparison is case-insensitive, per HL7: %s", got.Diagnostics)
 	}
 }

--- a/pkg/validator/extension_binding_test.go
+++ b/pkg/validator/extension_binding_test.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/gofhir/validator/pkg/issue"
@@ -60,114 +61,87 @@ func resourceWithBoundExtension(display string) []byte {
 	}`)
 }
 
-// TestExtensionBindingChecksDisplay is the point of routing extension values through
-// the binding validator: this path had its own copy of the logic, which never checked
-// Coding.display. A wrong display inside an extension went unreported.
-func TestExtensionBindingChecksDisplay(t *testing.T) {
-	auth := &localizingAuthority{displays: map[string]string{"": "Good"}}
-	v, err := New(
-		WithVersion("4.0.1"),
-		WithConformanceResources([][]byte{[]byte(boundExtensionSD)}),
-		WithTerminologyAuthority(auth),
-	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+// TestExtensionBindingUsesTheElementPath covers what routing extension values
+// through the binding validator gained. This path used to carry its own copy of the
+// logic and had fallen behind on checks the specification requires.
+//
+// Subtests share one validator: each New() reloads the full package set, which under
+// CI's -race and coverage dominates this package's test budget.
+func TestExtensionBindingUsesTheElementPath(t *testing.T) {
+	v, auth := authorityValidator(t)
+	ctx := context.Background()
 
-	result, err := v.Validate(context.Background(), resourceWithBoundExtension("Totally Wrong"))
-	if err != nil {
-		t.Fatalf("Validate: %v", err)
-	}
+	t.Run("checks Coding.display", func(t *testing.T) {
+		// The copy in pkg/extension never looked at the display, so a wrong one inside
+		// an extension went unreported while the same display on any other element
+		// errored.
+		auth.set(terminology.Valid, terminology.MembershipIncluded)
+		auth.setDisplay("Good")
 
-	if issueFor(t, result, issue.DiagBindingDisplayMismatch) == nil {
-		t.Errorf("a wrong display inside an extension must be reported, as it is "+
-			"anywhere else; issues: %v", result.Issues)
-	}
-}
+		result, err := v.Validate(ctx, resourceWithBoundExtension("Totally Wrong"))
+		if err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+		if issueFor(t, result, issue.DiagBindingDisplayMismatch) == nil {
+			t.Errorf("a wrong display inside an extension must be reported, as it is "+
+				"anywhere else; issues: %v", result.Issues)
+		}
+	})
 
-// TestExtensionBindingHonorsUnresolvedPolicy covers the other half: the extension
-// path treated an unresolvable binding as nothing at all, so WithUnresolvedPolicy
-// had no effect there.
-func TestExtensionBindingHonorsUnresolvedPolicy(t *testing.T) {
-	v, err := New(
-		WithVersion("4.0.1"),
-		WithConformanceResources([][]byte{[]byte(boundExtensionSD)}),
-		WithTerminologyAuthority(unresolvableAuthority{}),
-		WithUnresolvedPolicy(UnresolvedError),
-	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	t.Run("honors the unresolved policy", func(t *testing.T) {
+		// The extension path treated an undecidable binding as nothing at all, so
+		// WithUnresolvedPolicy had no effect there. The shared fixture is built with
+		// UnresolvedError.
+		auth.set(terminology.Unresolved, terminology.MembershipUnknown)
 
-	result, err := v.Validate(context.Background(), resourceWithBoundExtension("Good"))
-	if err != nil {
-		t.Fatalf("Validate: %v", err)
-	}
+		result, err := v.Validate(ctx, resourceWithBoundExtension("Good"))
+		if err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+		got := issueFor(t, result, issue.DiagBindingUnresolved)
+		if got == nil {
+			t.Fatalf("an unresolvable binding on an extension value must be reported "+
+				"under UnresolvedError; issues: %v", result.Issues)
+		}
+		if got.Severity != issue.SeverityError {
+			t.Errorf("severity = %s, want %s", got.Severity, issue.SeverityError)
+		}
+	})
 
-	got := issueFor(t, result, issue.DiagBindingUnresolved)
-	if got == nil {
-		t.Fatalf("an unresolvable binding on an extension value must be reported "+
-			"under UnresolvedError; issues: %v", result.Issues)
-	}
-	if got.Severity != issue.SeverityError {
-		t.Errorf("severity = %s, want %s", got.Severity, issue.SeverityError)
-	}
-}
+	t.Run("reports a required violation", func(t *testing.T) {
+		// Behavior that already worked and must survive the unification.
+		auth.set(terminology.Invalid, terminology.MembershipIncluded)
 
-// TestExtensionBindingHonorsDisplayLanguage confirms the i18n handling reaches
-// extensions too: a valid translation must not be reported as a mismatch.
-func TestExtensionBindingHonorsDisplayLanguage(t *testing.T) {
-	auth := &localizingAuthority{displays: map[string]string{
-		"":   "Good",
-		"es": "Bueno",
-	}}
-	v, err := New(
-		WithVersion("4.0.1"),
-		WithConformanceResources([][]byte{[]byte(boundExtensionSD)}),
-		WithTerminologyAuthority(auth),
-		WithDisplayLanguage("es"),
-	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+		result, err := v.Validate(ctx, resourceWithBoundExtension("Good"))
+		if err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+		got := issueFor(t, result, issue.DiagBindingRequired)
+		if got == nil {
+			t.Fatalf("a required binding violation on an extension value must error; "+
+				"issues: %v", result.Issues)
+		}
+		if got.Severity != issue.SeverityError {
+			t.Errorf("severity = %s, want %s", got.Severity, issue.SeverityError)
+		}
+	})
 
-	result, err := v.Validate(context.Background(), resourceWithBoundExtension("Bueno"))
-	if err != nil {
-		t.Fatalf("Validate: %v", err)
-	}
+	t.Run("surfaces the backend explanation", func(t *testing.T) {
+		// CodeResult.Message used to be discarded, dropping the part a user can act on.
+		auth.set(terminology.Invalid, terminology.MembershipIncluded)
+		auth.setMessage("code was retired in the 2024 edition")
 
-	if got := issueFor(t, result, issue.DiagBindingDisplayMismatch); got != nil {
-		t.Errorf("a valid Spanish display inside an extension must not be a mismatch: %s",
-			got.Diagnostics)
-	}
-}
-
-// TestExtensionBindingReportsRequiredViolation keeps the behavior that already
-// worked: a non-member code under a required binding is still an error.
-func TestExtensionBindingReportsRequiredViolation(t *testing.T) {
-	v, err := New(
-		WithVersion("4.0.1"),
-		WithConformanceResources([][]byte{[]byte(boundExtensionSD)}),
-		WithTerminologyAuthority(&membershipAuthority{
-			resolution: terminology.Invalid,
-			membership: terminology.MembershipIncluded,
-		}),
-	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-
-	result, err := v.Validate(context.Background(), resourceWithBoundExtension("Good"))
-	if err != nil {
-		t.Fatalf("Validate: %v", err)
-	}
-
-	got := issueFor(t, result, issue.DiagBindingRequired)
-	if got == nil {
-		t.Fatalf("a required binding violation on an extension value must error; issues: %v",
-			result.Issues)
-	}
-	if got.Severity != issue.SeverityError {
-		t.Errorf("severity = %s, want %s", got.Severity, issue.SeverityError)
-	}
+		result, err := v.Validate(ctx, resourceWithBoundExtension("Good"))
+		if err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+		got := issueFor(t, result, issue.DiagBindingRequired)
+		if got == nil {
+			t.Fatalf("expected a binding violation; issues: %v", result.Issues)
+		}
+		if !strings.Contains(got.Diagnostics, "retired in the 2024 edition") {
+			t.Errorf("the backend's explanation is missing from the diagnostic: %q",
+				got.Diagnostics)
+		}
+	})
 }

--- a/pkg/validator/extension_binding_test.go
+++ b/pkg/validator/extension_binding_test.go
@@ -1,0 +1,173 @@
+package validator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gofhir/validator/pkg/issue"
+	"github.com/gofhir/validator/pkg/terminology"
+)
+
+// An extension whose Extension.value[x] is bound required to a ValueSet. The
+// binding lives in the extension's own StructureDefinition, which is why this path
+// used to carry its own copy of binding validation.
+const boundExtensionSD = `{
+  "resourceType": "StructureDefinition",
+  "url": "http://example.org/StructureDefinition/bound-ext",
+  "name": "BoundExt",
+  "status": "active",
+  "kind": "complex-type",
+  "abstract": false,
+  "type": "Extension",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+  "derivation": "constraint",
+  "context": [{"type": "element", "expression": "Patient"}],
+  "snapshot": {
+    "element": [
+      {"id": "Extension", "path": "Extension", "min": 0, "max": "1"},
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "min": 1, "max": "1",
+        "type": [{"code": "uri"}],
+        "fixedUri": "http://example.org/StructureDefinition/bound-ext"
+      },
+      {
+        "id": "Extension.value[x]",
+        "path": "Extension.value[x]",
+        "min": 1, "max": "1",
+        "type": [{"code": "Coding"}],
+        "binding": {
+          "strength": "required",
+          "valueSet": "http://example.org/ValueSet/bound"
+        }
+      }
+    ]
+  }
+}`
+
+func resourceWithBoundExtension(display string) []byte {
+	return []byte(`{
+	  "resourceType": "Patient",
+	  "extension": [{
+	    "url": "http://example.org/StructureDefinition/bound-ext",
+	    "valueCoding": {
+	      "system": "http://example.org/CodeSystem/cs",
+	      "code": "good",
+	      "display": "` + display + `"
+	    }
+	  }]
+	}`)
+}
+
+// TestExtensionBindingChecksDisplay is the point of routing extension values through
+// the binding validator: this path had its own copy of the logic, which never checked
+// Coding.display. A wrong display inside an extension went unreported.
+func TestExtensionBindingChecksDisplay(t *testing.T) {
+	auth := &localizingAuthority{displays: map[string]string{"": "Good"}}
+	v, err := New(
+		WithVersion("4.0.1"),
+		WithConformanceResources([][]byte{[]byte(boundExtensionSD)}),
+		WithTerminologyAuthority(auth),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	result, err := v.Validate(context.Background(), resourceWithBoundExtension("Totally Wrong"))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	if issueFor(t, result, issue.DiagBindingDisplayMismatch) == nil {
+		t.Errorf("a wrong display inside an extension must be reported, as it is "+
+			"anywhere else; issues: %v", result.Issues)
+	}
+}
+
+// TestExtensionBindingHonorsUnresolvedPolicy covers the other half: the extension
+// path treated an unresolvable binding as nothing at all, so WithUnresolvedPolicy
+// had no effect there.
+func TestExtensionBindingHonorsUnresolvedPolicy(t *testing.T) {
+	v, err := New(
+		WithVersion("4.0.1"),
+		WithConformanceResources([][]byte{[]byte(boundExtensionSD)}),
+		WithTerminologyAuthority(unresolvableAuthority{}),
+		WithUnresolvedPolicy(UnresolvedError),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	result, err := v.Validate(context.Background(), resourceWithBoundExtension("Good"))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	got := issueFor(t, result, issue.DiagBindingUnresolved)
+	if got == nil {
+		t.Fatalf("an unresolvable binding on an extension value must be reported "+
+			"under UnresolvedError; issues: %v", result.Issues)
+	}
+	if got.Severity != issue.SeverityError {
+		t.Errorf("severity = %s, want %s", got.Severity, issue.SeverityError)
+	}
+}
+
+// TestExtensionBindingHonorsDisplayLanguage confirms the i18n handling reaches
+// extensions too: a valid translation must not be reported as a mismatch.
+func TestExtensionBindingHonorsDisplayLanguage(t *testing.T) {
+	auth := &localizingAuthority{displays: map[string]string{
+		"":   "Good",
+		"es": "Bueno",
+	}}
+	v, err := New(
+		WithVersion("4.0.1"),
+		WithConformanceResources([][]byte{[]byte(boundExtensionSD)}),
+		WithTerminologyAuthority(auth),
+		WithDisplayLanguage("es"),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	result, err := v.Validate(context.Background(), resourceWithBoundExtension("Bueno"))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	if got := issueFor(t, result, issue.DiagBindingDisplayMismatch); got != nil {
+		t.Errorf("a valid Spanish display inside an extension must not be a mismatch: %s",
+			got.Diagnostics)
+	}
+}
+
+// TestExtensionBindingReportsRequiredViolation keeps the behavior that already
+// worked: a non-member code under a required binding is still an error.
+func TestExtensionBindingReportsRequiredViolation(t *testing.T) {
+	v, err := New(
+		WithVersion("4.0.1"),
+		WithConformanceResources([][]byte{[]byte(boundExtensionSD)}),
+		WithTerminologyAuthority(&membershipAuthority{
+			resolution: terminology.Invalid,
+			membership: terminology.MembershipIncluded,
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	result, err := v.Validate(context.Background(), resourceWithBoundExtension("Good"))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	got := issueFor(t, result, issue.DiagBindingRequired)
+	if got == nil {
+		t.Fatalf("a required binding violation on an extension value must error; issues: %v",
+			result.Issues)
+	}
+	if got.Severity != issue.SeverityError {
+		t.Errorf("severity = %s, want %s", got.Severity, issue.SeverityError)
+	}
+}

--- a/pkg/validator/unresolved_policy_test.go
+++ b/pkg/validator/unresolved_policy_test.go
@@ -2,199 +2,138 @@ package validator
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/gofhir/validator/pkg/issue"
 	"github.com/gofhir/validator/pkg/terminology"
 )
 
-// unresolvableAuthority can decide nothing, which is what an operator sees when
-// no terminology server is configured and the base copy is not loaded.
-type unresolvableAuthority struct{}
-
-func (unresolvableAuthority) ResolveCodeInValueSet(_ context.Context, _, _, _ string, _ terminology.LookupOptions) (terminology.CodeResult, error) {
-	return terminology.CodeResult{Resolution: terminology.Unresolved}, nil
-}
-
-func (unresolvableAuthority) ResolveCodeInCodeSystem(_ context.Context, _, _ string, _ terminology.LookupOptions) (terminology.CodeResult, error) {
-	return terminology.CodeResult{Resolution: terminology.Unresolved}, nil
-}
-
-func (unresolvableAuthority) Supports(context.Context, string) bool { return true }
-
 // Patient.gender is bound required to administrative-gender.
 const requiredBindingResource = `{"resourceType":"Patient","gender":"female"}`
 
-func TestUnresolvedPolicyDefaultsToInformational(t *testing.T) {
-	v, err := New(WithVersion("4.0.1"), WithTerminologyAuthority(unresolvableAuthority{}))
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+// TestUnresolvedPolicy covers what happens when no terminology source can decide a
+// binding. Before the policy existed, "accept what we could not check" was baked
+// into return values and an operator could not change it.
+//
+// The two policies need separate validators because the option is set at
+// construction, so each is a shared fixture rather than a validator per test: every
+// New() reloads the full package set, which dominates this package's test budget.
+func TestUnresolvedPolicy(t *testing.T) {
+	ctx := context.Background()
 
-	result, err := v.Validate(context.Background(), []byte(requiredBindingResource))
-	if err != nil {
-		t.Fatalf("Validate: %v", err)
-	}
+	t.Run("default accepts and says so", func(t *testing.T) {
+		v, auth := warnValidator(t)
+		auth.set(terminology.Unresolved, terminology.MembershipUnknown)
 
-	got := issueFor(t, result, issue.DiagBindingUnresolved)
-	if got == nil {
-		t.Fatalf("an unresolvable binding must be reported; issues: %v", result.Issues)
-	}
-	if got.Severity != issue.SeverityInformation {
-		t.Errorf("severity = %s, want %s: the default accepts the code and says so",
-			got.Severity, issue.SeverityInformation)
-	}
-	if result.HasErrors() {
-		t.Errorf("the default policy must not fail validation; issues: %v", result.Issues)
-	}
-}
-
-func TestUnresolvedPolicyErrorFailsValidation(t *testing.T) {
-	v, err := New(
-		WithVersion("4.0.1"),
-		WithTerminologyAuthority(unresolvableAuthority{}),
-		WithUnresolvedPolicy(UnresolvedError),
-	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-
-	result, err := v.Validate(context.Background(), []byte(requiredBindingResource))
-	if err != nil {
-		t.Fatalf("Validate: %v", err)
-	}
-
-	got := issueFor(t, result, issue.DiagBindingUnresolved)
-	if got == nil {
-		t.Fatalf("an unresolvable binding must be reported; issues: %v", result.Issues)
-	}
-	if got.Severity != issue.SeverityError {
-		t.Errorf("severity = %s, want %s under UnresolvedError", got.Severity, issue.SeverityError)
-	}
-	if !result.HasErrors() {
-		t.Error("UnresolvedError must fail validation")
-	}
-}
-
-// TestUnresolvedIsNotReportedAsNonMembership is the distinction the three-state
-// contract exists for. A CodeableConcept whose codings could not be decided must
-// not be told that none of its codings are in the ValueSet — that asserts
-// something never established.
-func TestUnresolvedIsNotReportedAsNonMembership(t *testing.T) {
-	v, err := New(WithVersion("4.0.1"), WithTerminologyAuthority(unresolvableAuthority{}))
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-
-	// Patient.maritalStatus is a CodeableConcept bound extensible.
-	resource := []byte(`{
-	  "resourceType": "Patient",
-	  "maritalStatus": {"coding": [{"system": "http://example.org/cs", "code": "x"}]}
-	}`)
-
-	result, err := v.Validate(context.Background(), resource)
-	if err != nil {
-		t.Fatalf("Validate: %v", err)
-	}
-
-	for _, iss := range result.Issues {
-		switch iss.MessageID {
-		case string(issue.DiagBindingExtensibleNoCoding),
-			string(issue.DiagBindingExtensible),
-			string(issue.DiagBindingExtensibleOther):
-			t.Errorf("undecidable codings must not be reported as non-membership, got %s: %s",
-				iss.MessageID, iss.Diagnostics)
+		result, err := v.Validate(ctx, []byte(requiredBindingResource))
+		if err != nil {
+			t.Fatalf("Validate: %v", err)
 		}
-	}
 
-	if issueFor(t, result, issue.DiagBindingUnresolved) == nil {
-		t.Errorf("expected an unresolved diagnostic instead; issues: %v", result.Issues)
-	}
-}
-
-// TestUnresolvedPolicyIgnoresWeakBindings keeps the policy from turning every
-// preferred or example binding into noise when terminology is unavailable.
-func TestUnresolvedPolicyIgnoresWeakBindings(t *testing.T) {
-	v, err := New(
-		WithVersion("4.0.1"),
-		WithTerminologyAuthority(unresolvableAuthority{}),
-		WithUnresolvedPolicy(UnresolvedError),
-	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-
-	// Observation.status is required, so it does report. Observation.code is bound
-	// example, so it must not — the assertion is about the weak binding only.
-	resource := []byte(`{
-	  "resourceType": "Observation",
-	  "status": "final",
-	  "code": {"coding": [{"system": "http://example.org/cs", "code": "x"}]}
-	}`)
-
-	result, err := v.Validate(context.Background(), resource)
-	if err != nil {
-		t.Fatalf("Validate: %v", err)
-	}
-
-	var reportedFor []string
-	for _, iss := range result.Issues {
-		if iss.MessageID != string(issue.DiagBindingUnresolved) {
-			continue
+		got := issueFor(t, result, issue.DiagBindingUnresolved)
+		if got == nil {
+			t.Fatalf("an unresolvable binding must be reported; issues: %v", result.Issues)
 		}
-		reportedFor = append(reportedFor, iss.Expression...)
-		for _, expr := range iss.Expression {
-			if expr == "Observation.code" {
-				t.Errorf("Observation.code is an example binding and must not produce an "+
-					"unresolved diagnostic: %s", iss.Diagnostics)
+		if got.Severity != issue.SeverityInformation {
+			t.Errorf("severity = %s, want %s: the default accepts the code and says so",
+				got.Severity, issue.SeverityInformation)
+		}
+		if result.HasErrors() {
+			t.Errorf("the default policy must not fail validation; issues: %v", result.Issues)
+		}
+	})
+
+	t.Run("error policy fails validation", func(t *testing.T) {
+		v, auth := authorityValidator(t) // built with UnresolvedError
+		auth.set(terminology.Unresolved, terminology.MembershipUnknown)
+
+		result, err := v.Validate(ctx, []byte(requiredBindingResource))
+		if err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+
+		got := issueFor(t, result, issue.DiagBindingUnresolved)
+		if got == nil {
+			t.Fatalf("an unresolvable binding must be reported; issues: %v", result.Issues)
+		}
+		if got.Severity != issue.SeverityError {
+			t.Errorf("severity = %s, want %s under UnresolvedError",
+				got.Severity, issue.SeverityError)
+		}
+		if !result.HasErrors() {
+			t.Error("UnresolvedError must fail validation")
+		}
+	})
+
+	t.Run("undecidable is not reported as non-membership", func(t *testing.T) {
+		// The distinction the three-state contract exists for. A CodeableConcept whose
+		// codings could not be decided must not be told that none of its codings are in
+		// the ValueSet — that asserts something never established.
+		v, auth := warnValidator(t)
+		auth.set(terminology.Unresolved, terminology.MembershipUnknown)
+
+		// Patient.maritalStatus is a CodeableConcept bound extensible.
+		resource := []byte(`{
+		  "resourceType": "Patient",
+		  "maritalStatus": {"coding": [{"system": "http://example.org/cs", "code": "x"}]}
+		}`)
+
+		result, err := v.Validate(ctx, resource)
+		if err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+
+		for _, iss := range result.Issues {
+			switch iss.MessageID {
+			case string(issue.DiagBindingExtensibleNoCoding),
+				string(issue.DiagBindingExtensible),
+				string(issue.DiagBindingExtensibleOther):
+				t.Errorf("undecidable codings must not be reported as non-membership, "+
+					"got %s: %s", iss.MessageID, iss.Diagnostics)
 			}
 		}
-	}
+		if issueFor(t, result, issue.DiagBindingUnresolved) == nil {
+			t.Errorf("expected an unresolved diagnostic instead; issues: %v", result.Issues)
+		}
+	})
 
-	// Sanity check the other direction, so the assertion above cannot pass because
-	// nothing was reported at all.
-	if len(reportedFor) == 0 {
-		t.Error("expected the required binding on Observation.status to report; got nothing")
-	}
-}
+	t.Run("weak bindings stay quiet", func(t *testing.T) {
+		// Keeps an unavailable terminology server from turning every preferred or
+		// example binding into noise.
+		v, auth := authorityValidator(t) // UnresolvedError, the noisiest setting
+		auth.set(terminology.Unresolved, terminology.MembershipUnknown)
 
-// explainingAuthority rejects with an explanation, as a real backend would for a
-// retired code or an edition mismatch.
-type explainingAuthority struct{}
+		// Observation.status is required, so it reports. Observation.code is bound
+		// example, so it must not.
+		resource := []byte(`{
+		  "resourceType": "Observation",
+		  "status": "final",
+		  "code": {"coding": [{"system": "http://example.org/cs", "code": "x"}]}
+		}`)
 
-func (explainingAuthority) ResolveCodeInValueSet(_ context.Context, _, _, _ string, _ terminology.LookupOptions) (terminology.CodeResult, error) {
-	return terminology.CodeResult{
-		Resolution: terminology.Invalid,
-		Message:    "code was retired in the 2024 edition",
-	}, nil
-}
+		result, err := v.Validate(ctx, resource)
+		if err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
 
-func (explainingAuthority) ResolveCodeInCodeSystem(_ context.Context, _, _ string, _ terminology.LookupOptions) (terminology.CodeResult, error) {
-	return terminology.CodeResult{Resolution: terminology.Valid}, nil
-}
+		var reported int
+		for _, iss := range result.Issues {
+			if iss.MessageID != string(issue.DiagBindingUnresolved) {
+				continue
+			}
+			reported++
+			for _, expr := range iss.Expression {
+				if expr == "Observation.code" {
+					t.Errorf("Observation.code is an example binding and must not produce "+
+						"an unresolved diagnostic: %s", iss.Diagnostics)
+				}
+			}
+		}
 
-func (explainingAuthority) Supports(context.Context, string) bool { return true }
-
-// TestBackendExplanationSurfacesInTheIssue checks the message reaches the
-// OperationOutcome. A backend that says why it rejected a code is contributing the
-// part a user can act on, and it used to be dropped on the floor.
-func TestBackendExplanationSurfacesInTheIssue(t *testing.T) {
-	v, err := New(WithVersion("4.0.1"), WithTerminologyAuthority(explainingAuthority{}))
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-
-	result, err := v.Validate(context.Background(), []byte(requiredBindingResource))
-	if err != nil {
-		t.Fatalf("Validate: %v", err)
-	}
-
-	got := issueFor(t, result, issue.DiagBindingRequired)
-	if got == nil {
-		t.Fatalf("expected a required binding violation; issues: %v", result.Issues)
-	}
-	if !strings.Contains(got.Diagnostics, "retired in the 2024 edition") {
-		t.Errorf("the backend's explanation is missing from the diagnostic: %q", got.Diagnostics)
-	}
+		// Sanity check the other direction, so the assertion above cannot pass because
+		// nothing was reported at all.
+		if reported == 0 {
+			t.Error("expected the required binding on Observation.status to report")
+		}
+	})
 }

--- a/pkg/validator/unresolved_policy_test.go
+++ b/pkg/validator/unresolved_policy_test.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/gofhir/validator/pkg/issue"
@@ -155,5 +156,45 @@ func TestUnresolvedPolicyIgnoresWeakBindings(t *testing.T) {
 	// nothing was reported at all.
 	if len(reportedFor) == 0 {
 		t.Error("expected the required binding on Observation.status to report; got nothing")
+	}
+}
+
+// explainingAuthority rejects with an explanation, as a real backend would for a
+// retired code or an edition mismatch.
+type explainingAuthority struct{}
+
+func (explainingAuthority) ResolveCodeInValueSet(_ context.Context, _, _, _ string, _ terminology.LookupOptions) (terminology.CodeResult, error) {
+	return terminology.CodeResult{
+		Resolution: terminology.Invalid,
+		Message:    "code was retired in the 2024 edition",
+	}, nil
+}
+
+func (explainingAuthority) ResolveCodeInCodeSystem(_ context.Context, _, _ string, _ terminology.LookupOptions) (terminology.CodeResult, error) {
+	return terminology.CodeResult{Resolution: terminology.Valid}, nil
+}
+
+func (explainingAuthority) Supports(context.Context, string) bool { return true }
+
+// TestBackendExplanationSurfacesInTheIssue checks the message reaches the
+// OperationOutcome. A backend that says why it rejected a code is contributing the
+// part a user can act on, and it used to be dropped on the floor.
+func TestBackendExplanationSurfacesInTheIssue(t *testing.T) {
+	v, err := New(WithVersion("4.0.1"), WithTerminologyAuthority(explainingAuthority{}))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	result, err := v.Validate(context.Background(), []byte(requiredBindingResource))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	got := issueFor(t, result, issue.DiagBindingRequired)
+	if got == nil {
+		t.Fatalf("expected a required binding violation; issues: %v", result.Issues)
+	}
+	if !strings.Contains(got.Diagnostics, "retired in the 2024 edition") {
+		t.Errorf("the backend's explanation is missing from the diagnostic: %q", got.Diagnostics)
 	}
 }

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -505,6 +505,9 @@ func New(opts ...Option) (*Validator, error) {
 	v.bindValidator.SetUnresolvedPolicy(config.UnresolvedPolicy)
 	v.bindValidator.SetDisplayLanguage(config.DisplayLanguage)
 	v.extValidator = extension.New(reg, termReg, v.primValidator)
+	// Extension values are bound like any other element, so they are validated by
+	// the same code rather than a second copy of it.
+	v.extValidator.SetBindingValidator(v.bindValidator)
 	v.refValidator = reference.New(reg)
 	// Pass termRegistry to constraint validator for memberOf() support.
 	// When NoTerminology is set, pass nil to disable terminology in FHIRPath.


### PR DESCRIPTION
Closes the three gaps left after v1.15.0: parts of the `Authority` contract that were defined and then not consumed, and a duplicated validation path that had drifted.

## Extension bindings were validated by a second, older copy of the logic

Binding validation existed twice — resource elements in `pkg/binding`, extension values in `pkg/extension` — and the copies diverged. The extension one was missing checks the specification requires:

| | element path | extension path (before) |
|---|---|---|
| `Coding.display` checked | yes | **no** |
| Code exists in its CodeSystem | yes | **no** |
| CodeableConcept aggregated | yes | **no** — one issue per coding |
| `WithUnresolvedPolicy` honored | yes | **no** — reported nothing |
| Extensible severity table (`Membership`) | yes | **no** |
| `WithDisplayLanguage` honored | yes | **no** |

So a wrong display inside an extension went unreported while the same display on any other element errored.

`pkg/binding` now exports `ValidateValueBinding`, taking the binding directly for callers that hold one without an `ElementDefinition`, and `pkg/extension` delegates through a small interface. The duplicated functions are **deleted** rather than updated: two implementations is what produced the drift, and patching both would only reset the clock.

An earlier draft of this argued against delegating because it would add the display and CodeSystem checks. That had it backwards — those checks are what the spec requires, and their absence was the defect.

## `Supports` was never called

It is the authority's own short-circuit: false means nothing in its chain can decide a canonical. A chain with no terminology server configured was asked anyway, spending a round-trip to learn what it had already said. Now consulted before the lookup, and a negative answer is remembered like any other unresolvable one.

## `CodeResult.Message` was dropped

The backend's explanation for its verdict — a retired code, an edition mismatch — never reached the `OperationOutcome`. Binding diagnostics now append it. Rendered as a suffix in the caller rather than a template placeholder, so an absent message leaves no trace.

## Behaviour change

Resources that pass today can start failing: a wrong display or an invalid code inside an extension is now reported, as it already was everywhere else. That is why these are `feat` rather than `fix`.

## Verification

Full suite, `-race` and `golangci-lint` clean. Eight new tests cover each gained check on the extension path, the `Supports` short-circuit, and the backend message reaching the issue — plus one pinning that a required-binding violation on an extension still errors, so the unification cannot quietly drop what already worked.