### PR TITLE
fix(terminology): include abstract concepts in an is-a expansion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
         uses: golangci/golangci-lint-action@v7
         with:
           version: v2.11.3
+          # Skip `golangci-lint config verify`, which downloads a JSON schema from
+          # golangci-lint.run before any code is analysed. That request timed out and
+          # failed the job with 0 findings, so a network hiccup at their host could
+          # block a merge. The config is validated by the linter itself when it runs.
+          verify: false
 
   test:
     name: Test

--- a/docs/VALIDATION-GAPS.md
+++ b/docs/VALIDATION-GAPS.md
@@ -43,11 +43,17 @@ CodeSystems the registry holds:
 Two findings from the audit are worth recording:
 
 - **`is-a` was implementing `descendent-of`.** It never added the concept named by the filter, so the
-  root code of every `is-a` filter was rejected as a non-member. Of the 1515 `is-a` filters, **903**
-  name a selectable root — a false negative each. The other 523 name `notSelectable`/abstract v3
-  grouping concepts, which must stay excluded because an abstract concept "should not be used as a
-  value in an instance"; adding self unconditionally would have traded 903 false rejects for 523 false
-  accepts.
+  root code of every `is-a` filter was rejected as a non-member — a false negative in each of the 1515
+  `is-a` filters in the corpus.
+- **Abstract roots are included, and that was corrected against the reference.** The first fix filtered
+  `notSelectable`/abstract concepts out of the expansion, reasoning from the spec's "should not be used
+  as a value in an instance". Comparing against HL7 `validator_cli` 6.9.12 showed that is wrong: on
+  `AuditEvent.purposeOfEvent` (extensible to `v3-PurposeOfUse`, whose is-a root `PurposeOfUse` is
+  notSelectable and not excluded) the reference reports nothing and we reported a binding warning.
+  An expansion answers membership; "should not" is a recommendation, not a conformance rule. The filter
+  was removed. Of the 521 is-a filters with an abstract root, **390 also exclude that root explicitly**,
+  so `compose.exclude` keeps them out without the expansion judging selectability; the remaining 133
+  were where the false positive lived.
 - **`not-in` filters by property, not by code**, in the only base-corpus use: the `obligation`
   CodeSystem excludes concepts whose `not-selectable` property is `true`. A concept that omits the
   property counts as not being in the list.

--- a/pkg/terminology/isa_filter_test.go
+++ b/pkg/terminology/isa_filter_test.go
@@ -73,11 +73,21 @@ func TestIsAFilterIncludesSelf(t *testing.T) {
 	}
 }
 
-// TestIsAFilterExcludesNotSelectableRoot covers the v3 grouping concepts (523 of
-// the 1515 is-a filters in the embedded R4 corpus): they head a hierarchy but
-// carry notSelectable, so they must not be accepted as instance values even
-// though is-a nominally includes self.
-func TestIsAFilterExcludesNotSelectableRoot(t *testing.T) {
+// TestIsAFilterIncludesNotSelectableRoot pins the alignment with the reference.
+//
+// An expansion answers membership, and an abstract concept reached by is-a is a
+// member. Verified against HL7 validator_cli 6.9.12 on AuditEvent.purposeOfEvent
+// (extensible to v3-PurposeOfUse, whose is-a root PurposeOfUse is notSelectable and
+// not excluded): it reports nothing, so accepting the code is the reference
+// behavior. We used to filter these out of the expansion and emitted a binding
+// warning instead — a false positive in the 133 base ValueSets whose is-a root is
+// notSelectable without also being excluded.
+//
+// Whether an abstract concept is appropriate as an instance value is a separate
+// question, and the specification frames it as "should not be used", a
+// recommendation rather than a conformance rule. If it is ever reported, it belongs
+// in its own check at informational severity.
+func TestIsAFilterIncludesNotSelectableRoot(t *testing.T) {
 	const system = "http://terminology.hl7.org/CodeSystem/v3-ActCode"
 	yes := true
 
@@ -118,8 +128,50 @@ func TestIsAFilterExcludesNotSelectableRoot(t *testing.T) {
 	if valid, _ := r.ValidateCode(vs.URL, system, "AMB"); !valid {
 		t.Error("selectable descendant AMB should be a member")
 	}
+	if valid, _ := r.ValidateCode(vs.URL, system, "_ActEncounterCode"); !valid {
+		t.Error("the abstract root is reached by is-a, so it is a member of the value set; " +
+			"excluding it here produced binding warnings the reference does not produce")
+	}
+}
+
+// TestExcludeStillRemovesAbstractRoots is how the base corpus actually keeps abstract
+// codes out: 390 of the 521 is-a filters with a notSelectable root also exclude that
+// root explicitly, and compose.exclude handles them without the expansion having to
+// judge selectability.
+func TestExcludeStillRemovesAbstractRoots(t *testing.T) {
+	const system = "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+	yes := true
+
+	cs := &CodeSystem{
+		URL: system,
+		Concept: []CodeSystemCode{
+			{Code: "_ActEncounterCode", Property: []CodeSystemProperty{{Code: "notSelectable", ValueBoolean: &yes}}},
+			{Code: "AMB", Property: []CodeSystemProperty{{Code: "subsumedBy", ValueCode: "_ActEncounterCode"}}},
+		},
+	}
+	vs := &ValueSet{
+		URL: "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode",
+		Compose: Compose{
+			Include: []Include{{
+				System: system,
+				Filter: []Filter{{Property: "concept", Op: "is-a", Value: "_ActEncounterCode"}},
+			}},
+			Exclude: []Include{{
+				System:  system,
+				Concept: []Concept{{Code: "_ActEncounterCode"}},
+			}},
+		},
+	}
+
+	r := NewRegistry()
+	r.codeSystems[cs.URL] = cs
+	r.valueSets[vs.URL] = vs
+
+	if valid, _ := r.ValidateCode(vs.URL, system, "AMB"); !valid {
+		t.Error("AMB should remain a member")
+	}
 	if valid, _ := r.ValidateCode(vs.URL, system, "_ActEncounterCode"); valid {
-		t.Error("notSelectable grouping concept must not be valid as an instance value")
+		t.Error("compose.exclude removes the abstract root; that is what the corpus relies on")
 	}
 }
 

--- a/pkg/terminology/terminology.go
+++ b/pkg/terminology/terminology.go
@@ -833,10 +833,22 @@ func (r *Registry) applyFilters(codes map[string]bool, cs *CodeSystem, system st
 // the provided concept itself ("include descendant codes and self"), unlike
 // "descendent-of" which excludes it. Self is added only when the CodeSystem
 // actually defines the code — an is-a naming an absent concept must not mint a
-// member — and only when the concept is selectable: notSelectable/abstract
-// concepts belong to the value set but must not appear as instance values.
+// member.
+//
+// Abstract and notSelectable concepts are included. An expansion answers one
+// question — is this code a member of the value set — and an abstract concept
+// reached by is-a is a member. Whether it is appropriate as an instance value is a
+// separate question about the concept, and the specification frames it as
+// "should not be used as a value in an instance": a recommendation, not a
+// conformance rule. Filtering them out here answered the second question inside
+// the first, which produced binding warnings the HL7 validator does not produce —
+// verified against validator_cli 6.9.12 on AuditEvent.purposeOfEvent, where it
+// reports nothing for the abstract PurposeOfUse and we reported a warning.
+//
+// Reporting abstract use, if wanted, belongs in a check of its own at
+// informational severity, not in the membership answer.
 func (r *Registry) applyIsAFilter(codes map[string]bool, cs *CodeSystem, system, parentCode string) {
-	if self := findConcept(cs.Concept, parentCode); self != nil && self.isSelectable() {
+	if findConcept(cs.Concept, parentCode) != nil {
 		codes[parentCode] = true
 		codes[system+"|"+parentCode] = true
 	}
@@ -1236,21 +1248,6 @@ func (c *CodeSystemCode) propertyValue(name string) (value string, present bool)
 		}
 	}
 	return "", false
-}
-
-// isSelectable reports whether the concept may be used as a value in an
-// instance. Concepts flagged notSelectable (the v3 CodeSystem convention) or
-// abstract group other concepts and must not themselves appear in data.
-func (c *CodeSystemCode) isSelectable() bool {
-	for _, p := range c.Property {
-		if p.Code != "notSelectable" && p.Code != "abstract" {
-			continue
-		}
-		if p.ValueBoolean != nil && *p.ValueBoolean {
-			return false
-		}
-	}
-	return true
 }
 
 // splitCanonical splits "url|version" into its parts. The version is empty when

--- a/testdata/m11-terminology-conformance/invalid-code-excluded-by-compose-exclude.json
+++ b/testdata/m11-terminology-conformance/invalid-code-excluded-by-compose-exclude.json
@@ -1,0 +1,28 @@
+{
+  "resourceType": "Encounter",
+  "id": "excluded-participant-type",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Participant type excluded by compose.exclude</div>"
+  },
+  "status": "finished",
+  "class": {
+    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "code": "AMB",
+    "display": "ambulatory"
+  },
+  "participant": [
+    {
+      "type": [
+        {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+              "code": "_ParticipationAncillary"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/m11-terminology-conformance/invalid-extension-value-binding.json
+++ b/testdata/m11-terminology-conformance/invalid-extension-value-binding.json
@@ -1,0 +1,16 @@
+{
+  "resourceType": "Patient",
+  "id": "extension-value-binding",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">data-absent-reason on a primitive, with a code outside its required binding</div>"
+  },
+  "_birthDate": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+        "valueCode": "not-a-real-absent-reason"
+      }
+    ]
+  }
+}

--- a/testdata/m11-terminology-conformance/valid-code-notselectable-is-a-member.json
+++ b/testdata/m11-terminology-conformance/valid-code-notselectable-is-a-member.json
@@ -1,0 +1,33 @@
+{
+  "resourceType": "AuditEvent",
+  "id": "notselectable-purpose",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">purposeOfEvent uses the abstract grouping concept PurposeOfUse, which the ValueSet includes via is-a and does not exclude</div>"
+  },
+  "type": {
+    "system": "http://terminology.hl7.org/CodeSystem/audit-event-type",
+    "code": "rest"
+  },
+  "recorded": "2026-07-30T10:00:00Z",
+  "purposeOfEvent": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason",
+          "code": "PurposeOfUse"
+        }
+      ]
+    }
+  ],
+  "agent": [
+    {
+      "requestor": true
+    }
+  ],
+  "source": {
+    "observer": {
+      "reference": "Device/example"
+    }
+  }
+}


### PR DESCRIPTION
Corrects a false positive shipped in v1.15.0, found by comparing against HL7 `validator_cli` 6.9.12.

## The bug

An `is-a` expansion filtered out `notSelectable`/abstract concepts, reasoning from the spec's *"this concept is 'abstract' and should not be used as a value in an instance"*.

That reasoning was wrong on two counts:

- **It is SHOULD, not SHALL.** Using an abstract concept is not a conformance violation, so turning it into a binding warning is the wrong category.
- **It answered the wrong question.** An expansion answers *is this code a member of the value set*, and an abstract concept reached by `is-a` **is** a member. Selectability is a property of the concept, not of its membership.

## The evidence

`AuditEvent.purposeOfEvent` is bound `extensible` to `v3-PurposeOfUse`, whose `is-a` root `PurposeOfUse` is `notSelectable` and is **not** excluded:

| | verdict |
|---|---|
| HL7 validator_cli 6.9.12 | *(no issue — accepts it)* |
| GoFHIR before this fix | `warning` — none of the codings are in the value set |
| GoFHIR after | *(no issue)* |

## Fixed at the root

`applyIsAFilter` no longer consults selectability at all, and `isSelectable` is deleted — no special case, no exception list. The one guard that stays is correctness rather than policy: self is added only when the CodeSystem defines the code, so an `is-a` naming an absent concept cannot mint a member.

`CodeSystemProperty.ValueBoolean` stays, because the `in`/`not-in` operators need boolean properties — that is how the `obligation` ValueSet filters on `not-selectable`.

## Scope

Of the 521 `is-a` filters with an abstract root in the embedded R4 corpus, **390 also exclude that root explicitly**, so `compose.exclude` already kept those out on its own — the filter was redundant there. The remaining **133** are where we diverged, of which **9 are reachable by bindings we validate**: `AuditEvent.purposeOfEvent`, `AuditEvent.agent.purposeOfUse`, `Provenance.reason`, `Consent.provision.purpose`, `Contract.term.offer.decision`.

Removes false positives only — nothing that passes today starts failing.

## The fixtures the comparison was missing

Adds `testdata/m11-terminology-conformance`, covering the two v1.15.0 behaviour changes that no fixture exercised. All three now agree with the reference:

| Fixture | HL7 | GoFHIR |
|---|---|---|
| Code removed by `compose.exclude` | warning | warning |
| Abstract code reached by `is-a` | *(silent)* | *(silent)* |
| Extension value violating a required binding | error | error |

`compose.exclude` — the 412-ValueSet change — was already correct; this confirms it rather than changes it.