### PR TITLE
docs: note to GoFHIR Server for v1.16.1, and two doc/code drifts

### DIFF
--- a/.claude/skills/validator-compare/SKILL.md
+++ b/.claude/skills/validator-compare/SKILL.md
@@ -46,7 +46,7 @@ Si NO existe validator_cli.jar:
 
 ```bash
 # Compilar el validador Go
-cd /Users/robertoaraneda/projects/personal/opensource/validator
+cd /Users/robertoaraneda/projects/personal/opensource/go-validator
 go build -o bin/gofhir-validator ./cmd/gofhir-validator/
 ```
 
@@ -66,7 +66,7 @@ Capturar:
 
 ```bash
 # Ejecutar GoFHIR validator y capturar output
-./bin/gofhir-validator -version r4 <archivo> 2>&1
+./bin/gofhir-validator -version 4.0.1 <archivo> 2>&1
 ```
 
 Capturar:
@@ -119,7 +119,7 @@ java -jar validator_cli.jar <file> -version 4.0.1
 ### GoFHIR Validator
 **Comando:**
 ```bash
-gofhir-validator -version r4 <file>
+gofhir-validator -version 4.0.1 <file>
 ```
 
 **Output:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,7 +255,7 @@ go install github.com/gofhir/validator/cmd/gofhir-validator@latest
 gofhir-validator patient.json
 
 # Especificar versión FHIR
-gofhir-validator -version r4 patient.json
+gofhir-validator -version 4.0.1 patient.json
 
 # Validar contra profile
 gofhir-validator -ig http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient patient.json
@@ -271,7 +271,7 @@ cat patient.json | gofhir-validator -
 
 | gofhir-validator | HL7 validator | Descripción |
 |------------------|---------------|-------------|
-| `-version r4` | `-version 4.0.1` | Versión FHIR |
+| `-version 4.0.1` | `-version 4.0.1` | Versión FHIR (acepta 4.0.1, 4.3.0, 5.0.0) |
 | `-ig <url>` | `-ig <url>` | Profile/IG |
 | `-output json` | `-output` | Formato salida |
 | `-tx n/a` | `-tx n/a` | Deshabilitar terminología |

--- a/docs/plans/2026-07-30-note-to-server-v1.16.0.md
+++ b/docs/plans/2026-07-30-note-to-server-v1.16.0.md
@@ -1,0 +1,127 @@
+# v1.15.0 and v1.16.0 are out — what changed since you signed the contract
+
+**For:** GoFHIR Server (terminology, ADR-014)
+**From:** the `github.com/gofhir/validator` maintainers
+**Date:** 2026-07-30
+**Re:** rounds 1–9; releases v1.15.0 and v1.16.0
+
+Your blocker is lifted: `go get github.com/gofhir/validator@v1.16.0` has the `Authority`
+port. Everything we owed from the shared work order is shipped.
+
+Five things below need action on your side, and two correct an expectation we set.
+
+## 1. Contract changes since your round-7 sign-off
+
+Three, all additive except the first, which is a rename you must apply.
+
+**Method names are `Resolve*`, not `ValidateCode*`.** `ResolveCodeInValueSet` and
+`ResolveCodeInCodeSystem`. The frozen names collided with `Provider`'s, and Go permits
+one method per name per type — so no single type could have implemented both ports,
+which is the migration path we both agreed on. If you started against the round-6
+names, they do not compile. `authority_test.go` has a dual-adapter assertion so the
+clash cannot silently return.
+
+**`LookupOptions` gained `SystemVersion`.** `Coding.version` declares which version of a
+CodeSystem a code was authored against, and it was being dropped. Route it to whatever
+version your chain holds. Additive — a struct field, so your implementation keeps
+compiling without it.
+
+**`SystemInValueSet` must be `MembershipUnknown` when `system` is empty.** A primitive
+`code` element carries no system — it is implied by the ValueSet — so there is no other
+system to be extending with, and `Included`/`Excluded` would both assert something
+meaningless. This is the case you raised: we route those with `system=""` so your
+adapter can resolve them against the ValueSet's declared systems.
+
+## 2. Two fields you implement that now actually do something
+
+Both were defined in the contract and then ignored on our side. Fixed in v1.16.0, so
+implementing them faithfully now has an effect:
+
+- **`Supports`** is consulted before the lookup. Answer `false` when nothing in your
+  chain can decide a canonical and we skip the round-trip, remembering it like any other
+  unresolvable answer. Optimistic `true` remains fine — that is what we agreed a
+  networked chain can honestly promise.
+- **`CodeResult.Message`** is appended to the binding diagnostic. If you explain a
+  verdict — retired code, edition mismatch — it reaches the OperationOutcome instead of
+  being discarded.
+
+## 3. Behaviour changes to audit your fixtures against
+
+You already flagged this at the bump. Ranked by how much surface each touches:
+
+| Change | Direction | Scope |
+| --- | --- | --- |
+| `compose.exclude` now applied | accept → **reject** | 412 of 3237 base ValueSets carry exclusions |
+| `is-a` includes the named concept | reject → **accept** | 903 selectable root codes |
+| `is-a` still excludes `notSelectable` | unchanged (reject) | 523 abstract v3 grouping concepts |
+| Extension value bindings fully validated | new issues | any resource with a bound extension |
+| `Coding.version` honored | can flip either way | codings that declare a version |
+
+The extension one is the least obvious and the most likely to surprise you. Binding
+validation for extension values used to run on a second, older copy of the logic that
+never checked `Coding.display`, never checked whether a code exists in its own
+CodeSystem, reported one issue per coding instead of aggregating a CodeableConcept, and
+treated an unresolvable binding as nothing at all. It now goes through the same code as
+any other element, so a resource with a wrong display inside an extension starts
+failing where it used to pass.
+
+Three new diagnostics, all non-failing by default: `BINDING_UNRESOLVED`,
+`BINDING_EXTENSIBLE_OTHER_SYSTEM` (information, deliberately, so `-strict` does not flip
+it to a failure), `BINDING_EXTENSIBLE_UNKNOWN_SYSTEM`.
+
+## 4. Two expectations we set that were wrong
+
+**Reclaimed heap is ~15 MiB, not ~60 MiB.** Measured: 95 MiB resident for a validator
+without an authority, 80 MiB with one. Our parser keeps only what validation needs —
+compose, concept codes, a few properties — and discards narrative, description and
+contact, so our copy of the same 3237 ValueSets was never equivalent to yours. Your
+~60 MiB does not go away by switching, because your store still backs `$expand`. The RFC
+assumed a symmetric duplicate and there wasn't one.
+
+**Provider-first does not regress throughput, so your condition is met.** On a 25-entry
+Bundle with CI's flags:
+
+```
+local terminology     10.03 ms/op   43701 allocs
+with authority         9.80 ms/op   43644 allocs
+```
+
+Marginally *faster*: skipping the base terminology also skips expanding ValueSets and
+maintaining the expansion cache, which costs more than the extra indirection. At the
+~1.1 µs/lookup you measured against your in-memory layer, real chain latency adds about
+1.4% on this Bundle. The ~1000× per-element concern does not materialise.
+
+## 5. What we verified against the reference, and what we did not
+
+We compared against HL7 `validator_cli` 6.9.12 over 25 fixtures (`m5-coding`,
+`m6-codeableconcept`, `m7-bindings`, `m8-extensions`). Where it overlaps your interests
+we agree with the reference: display mismatch is an **error** on both sides, `required`
+bindings on primitive `code` elements are errors on both, text-only CodeableConcept
+under an extensible binding is a warning on both.
+
+**Not verified: `compose.exclude` and the `notSelectable` exclusion.** No fixture in the
+suite exercises either, so the two largest behaviour changes rest on our reading of the
+specification rather than on agreement with the reference. Same for bindings inside
+extensions — the `m8` fixtures cover context, value type and URL, not bindings.
+
+If your corpus has resources that hit a ValueSet with `compose.exclude`, or that use an
+abstract v3 code such as `_ActEncounterCode`, those are the most valuable thing you could
+send us. They close the gap that matters most.
+
+One thing the comparison surfaced that is worth knowing: HL7's validator connects to
+`tx.fhir.org`. Several apparent gaps on our side — no verdict on LOINC or SNOMED codes,
+silence where it reports a code system as unresolvable — are the absence of a configured
+terminology server, not missing logic. Those close when your chain is the authority, not
+by changing our code.
+
+## 6. Your migration, unchanged
+
+1. Bump to `v1.16.0` and audit fixtures against the table in §3.
+2. Implement `Authority` with the `Resolve*` names, returning `MembershipUnknown` for an
+   empty system, routing `SystemVersion`, populating `Message`, and answering `Supports`
+   honestly.
+3. Switch the primary to `WithTerminologyAuthority`. Optionally set
+   `WithUnresolvedPolicy(UnresolvedError)` if you want closed-world validation, and
+   `WithDisplayLanguage` once `memory.Store` carries designations — display comparison is
+   skipped rather than run against English until then, so there is no rush and no false
+   rejections in the meantime.

--- a/docs/plans/2026-07-30-note-to-server-v1.16.1.md
+++ b/docs/plans/2026-07-30-note-to-server-v1.16.1.md
@@ -1,12 +1,15 @@
-# v1.15.0 and v1.16.0 are out — what changed since you signed the contract
+# v1.15.0, v1.16.0 and v1.16.1 are out — what changed since you signed the contract
 
 **For:** GoFHIR Server (terminology, ADR-014)
 **From:** the `github.com/gofhir/validator` maintainers
 **Date:** 2026-07-30
-**Re:** rounds 1–9; releases v1.15.0 and v1.16.0
+**Re:** rounds 1–9; releases v1.15.0, v1.16.0 and v1.16.1
 
-Your blocker is lifted: `go get github.com/gofhir/validator@v1.16.0` has the `Authority`
+Your blocker is lifted: `go get github.com/gofhir/validator@v1.16.1` has the `Authority`
 port. Everything we owed from the shared work order is shipped.
+
+Take **v1.16.1**, not v1.16.0: the patch removes a false positive that was present in
+both earlier releases. §5 explains it, and it changes one row of the audit table.
 
 Five things below need action on your side, and two correct an expectation we set.
 
@@ -53,7 +56,7 @@ You already flagged this at the bump. Ranked by how much surface each touches:
 | --- | --- | --- |
 | `compose.exclude` now applied | accept → **reject** | 412 of 3237 base ValueSets carry exclusions |
 | `is-a` includes the named concept | reject → **accept** | 903 selectable root codes |
-| `is-a` still excludes `notSelectable` | unchanged (reject) | 523 abstract v3 grouping concepts |
+| `is-a` includes `notSelectable` roots | **fixed in v1.16.1** — see §5 | 133 ValueSets, 9 reachable bindings |
 | Extension value bindings fully validated | new issues | any resource with a bound extension |
 | `Coding.version` honored | can flip either way | codings that declare a version |
 
@@ -91,22 +94,42 @@ maintaining the expansion cache, which costs more than the extra indirection. At
 ~1.1 µs/lookup you measured against your in-memory layer, real chain latency adds about
 1.4% on this Bundle. The ~1000× per-element concern does not materialise.
 
-## 5. What we verified against the reference, and what we did not
+## 5. What we verified against the reference — and the false positive it found
 
-We compared against HL7 `validator_cli` 6.9.12 over 25 fixtures (`m5-coding`,
-`m6-codeableconcept`, `m7-bindings`, `m8-extensions`). Where it overlaps your interests
-we agree with the reference: display mismatch is an **error** on both sides, `required`
-bindings on primitive `code` elements are errors on both, text-only CodeableConcept
-under an extensible binding is a warning on both.
+We compared against HL7 `validator_cli` 6.9.12. Where it overlaps your interests we agree:
+display mismatch is an **error** on both sides, `required` bindings on primitive `code`
+elements are errors on both, text-only CodeableConcept under an extensible binding is a
+warning on both.
 
-**Not verified: `compose.exclude` and the `notSelectable` exclusion.** No fixture in the
-suite exercises either, so the two largest behaviour changes rest on our reading of the
-specification rather than on agreement with the reference. Same for bindings inside
-extensions — the `m8` fixtures cover context, value type and URL, not bindings.
+Two fixtures were missing from the suite, so the two largest behaviour changes of v1.15.0
+were unverified. We wrote them (`testdata/m11-terminology-conformance`) and one of them
+found a bug of ours:
 
-If your corpus has resources that hit a ValueSet with `compose.exclude`, or that use an
-abstract v3 code such as `_ActEncounterCode`, those are the most valuable thing you could
-send us. They close the gap that matters most.
+| Case | HL7 | v1.15.0 / v1.16.0 | v1.16.1 |
+| --- | --- | --- | --- |
+| Code removed by `compose.exclude` | warning | warning | warning ✅ |
+| Abstract code reached by `is-a` | *(silent)* | **warning** ❌ | *(silent)* ✅ |
+| Extension value violating a required binding | error | error | error ✅ |
+
+**`compose.exclude` — the 412-ValueSet change — was correct all along.** The fixture
+confirms it rather than changing it, so nothing to re-audit there.
+
+**Abstract concepts were wrongly rejected.** We had filtered `notSelectable`/abstract
+concepts out of an `is-a` expansion, reasoning from the spec's *"this concept is 'abstract'
+and should not be used as a value in an instance"*. Wrong twice over: it is SHOULD, not
+SHALL, so using one is not a conformance violation; and an expansion answers membership,
+which an abstract concept reached by `is-a` has. `AuditEvent.purposeOfEvent` is the case
+that settled it — bound extensible to `v3-PurposeOfUse`, whose `is-a` root `PurposeOfUse`
+is notSelectable and not excluded — where the reference reports nothing and we reported a
+warning.
+
+Scope, in case you saw it: of the 521 `is-a` filters with an abstract root, **390 also
+exclude that root explicitly**, so `compose.exclude` kept those out on its own and our
+filter was redundant there. The 133 remaining are where we diverged, of which 9 are
+reachable by bindings we validate — `AuditEvent.purposeOfEvent`,
+`AuditEvent.agent.purposeOfUse`, `Provenance.reason`, `Consent.provision.purpose`,
+`Contract.term.offer.decision`. If your fixtures touch those, v1.16.0 gave you spurious
+warnings and v1.16.1 does not.
 
 One thing the comparison surfaced that is worth knowing: HL7's validator connects to
 `tx.fhir.org`. Several apparent gaps on our side — no verdict on LOINC or SNOMED codes,
@@ -116,7 +139,7 @@ by changing our code.
 
 ## 6. Your migration, unchanged
 
-1. Bump to `v1.16.0` and audit fixtures against the table in §3.
+1. Bump to `v1.16.1` and audit fixtures against the table in §3.
 2. Implement `Authority` with the `Resolve*` names, returning `MembershipUnknown` for an
    empty system, routing `SystemVersion`, populating `Message`, and answering `Supports`
    honestly.


### PR DESCRIPTION
Docs only. Three commits, each one thing.

## Note to GoFHIR Server

Closes the nine-round design exchange: what changed in the `Authority` contract since their round-7 sign-off, the behaviour changes to audit their fixtures against, and two expectations we had set wrong (the reclaimed heap is ~15 MiB, not ~60; provider-first does not regress throughput, so their blocking condition is met).

Updated for **v1.16.1**, because the earlier draft told them to take v1.16.0 and listed the `notSelectable` exclusion as intended behaviour — both wrong after the fix in #67. The verification section now carries what the three new fixtures found, and names the five bindings where they may have seen spurious warnings on v1.16.0: `AuditEvent.purposeOfEvent`, `AuditEvent.agent.purposeOfUse`, `Provenance.reason`, `Consent.provision.purpose`, `Contract.term.offer.decision`.

## Two doc/code drifts, both found by using the docs

**`-version r4` does not work.** CLAUDE.md documented it, and its comparison table claimed it as our equivalent of HL7's `-version 4.0.1`. The CLI rejects it:

```
unknown FHIR version: r4 (supported: 4.0.1, 4.3.0, 5.0.0)
```

Twenty-five comparison runs failed on that before it was clear the docs were wrong rather than the invocation. The `validator-compare` skill carried the same flag, plus a `cd` into `opensource/validator` — the repo before it was renamed to `go-validator`.

Same pattern the VALIDATION-GAPS.md pass was cleaning up: documentation asserting something the code contradicts. A doc that makes the documented command fail is worse than no doc.