### PR TITLE
feat(binding): report a Coding that is missing its system or its code

### DIFF
--- a/pkg/binding/binding.go
+++ b/pkg/binding/binding.go
@@ -322,9 +322,25 @@ func (v *Validator) checkConceptCodings(ctx context.Context, cc map[string]any, 
 func (v *Validator) checkCodingAgainstCodeSystem(ctx context.Context, coding map[string]any, fhirPath string, result *issue.Result) {
 	system, _ := coding["system"].(string)
 	code, _ := coding["code"].(string)
-	if system == "" || code == "" {
+
+	// A Coding that names no system cannot be placed in any vocabulary, and one that names
+	// a system without a code identifies nothing in it. Neither is decidable, so both are
+	// reported here rather than falling through to a lookup that cannot answer.
+	//
+	// The severities differ, and follow the reference: a missing system is a warning because
+	// the concept may still be conveyed by CodeableConcept.text, whereas a system with no
+	// code is an error — the instance committed to a vocabulary and then said nothing in it.
+	// Verified against HL7 validator_cli 6.9.12; both are reported on the Coding itself, not
+	// on a child, since the defect is the combination rather than either value.
+	switch {
+	case system == "":
+		result.AddWarningWithID(issue.DiagCodingNoSystem, nil, fhirPath)
+		return
+	case code == "":
+		result.AddErrorWithID(issue.DiagCodingNoCode, map[string]any{"system": system}, fhirPath)
 		return
 	}
+
 	systemVersion, _ := coding["version"].(string)
 	providedDisplay, _ := coding["display"].(string)
 

--- a/pkg/issue/diagnostics.go
+++ b/pkg/issue/diagnostics.go
@@ -40,6 +40,8 @@ const (
 	DiagBindingValueSetNotFound   DiagnosticID = "BINDING_VALUESET_NOT_FOUND"
 	DiagCodeNotInCodeSystem       DiagnosticID = "CODE_NOT_IN_CODESYSTEM"
 	DiagCodeSystemNotFound        DiagnosticID = "CODESYSTEM_NOT_FOUND"
+	DiagCodingNoSystem            DiagnosticID = "CODING_NO_SYSTEM"
+	DiagCodingNoCode              DiagnosticID = "CODING_NO_CODE"
 )
 
 // Diagnostic IDs for extension validation (M8).
@@ -283,6 +285,16 @@ var diagnosticTemplates = map[DiagnosticID]DiagnosticTemplate{
 		Severity: SeverityWarning,
 		Code:     CodeProcessing,
 		Template: "None of the codings provided are in the value set '{valueSet}', and a coding should come from this value set unless it has no suitable code (note that the validator cannot judge what is suitable) (codes = {codes})",
+	},
+	DiagCodingNoSystem: {
+		Severity: SeverityWarning,
+		Code:     CodeProcessing,
+		Template: "Coding has no system. A code with no system has no defined meaning, and it cannot be validated. A system should be provided",
+	},
+	DiagCodingNoCode: {
+		Severity: SeverityError,
+		Code:     CodeInvalid,
+		Template: "Coding has no code for system {system} and cannot be validated",
 	},
 
 	// Extension (M8)

--- a/pkg/validator/coding_structure_test.go
+++ b/pkg/validator/coding_structure_test.go
@@ -1,0 +1,133 @@
+package validator
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gofhir/validator/pkg/issue"
+)
+
+// A Coding is only interpretable as a pair. These tests cover the two ways it can fail to
+// be one, and the case that must stay silent.
+//
+// All three were verified against HL7 validator_cli 6.9.12 before being written here, so
+// the expectations are the reference's, not ours.
+
+// TestCodingWithNoSystemIsWarned covers a code that names no vocabulary. It is a warning
+// rather than an error because the concept may still be carried by CodeableConcept.text.
+func TestCodingWithNoSystemIsWarned(t *testing.T) {
+	v := getSharedValidator(t)
+
+	resource := []byte(`{
+	  "resourceType": "Observation",
+	  "status": "final",
+	  "text": {"status": "generated", "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">probe</div>"},
+	  "code": {"coding": [{"code": "1234-5", "display": "Some code"}]}
+	}`)
+
+	result, err := v.Validate(context.Background(), resource)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	got := issueFor(t, result, issue.DiagCodingNoSystem)
+	if got == nil {
+		t.Fatalf("a Coding with no system cannot be placed in any vocabulary and must be "+
+			"reported; issues: %v", result.Issues)
+	}
+	if got.Severity != issue.SeverityWarning {
+		t.Errorf("severity = %s, want %s", got.Severity, issue.SeverityWarning)
+	}
+	// On the Coding, not a child: the defect is the absence of one of its two halves.
+	if len(got.Expression) == 0 || !strings.HasSuffix(got.Expression[0], ".coding[0]") {
+		t.Errorf("expression = %v, want the Coding itself", got.Expression)
+	}
+}
+
+// TestCodingWithNoSystemIsWarnedWithoutACode checks the condition is the missing system
+// alone. A Coding carrying only a display is just as unplaceable, and the reference
+// reports the same warning there.
+func TestCodingWithNoSystemIsWarnedWithoutACode(t *testing.T) {
+	v := getSharedValidator(t)
+
+	resource := []byte(`{
+	  "resourceType": "Observation",
+	  "status": "final",
+	  "text": {"status": "generated", "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">probe</div>"},
+	  "code": {"coding": [{"display": "Just a display"}]}
+	}`)
+
+	result, err := v.Validate(context.Background(), resource)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	if issueFor(t, result, issue.DiagCodingNoSystem) == nil {
+		t.Errorf("a Coding with neither system nor code must still be reported; issues: %v",
+			result.Issues)
+	}
+}
+
+// TestCodingWithSystemButNoCodeIsError is the more severe half. Naming a vocabulary and
+// then saying nothing in it is not a judgement call the reader can recover from, unlike a
+// missing system where text may still carry the meaning.
+func TestCodingWithSystemButNoCodeIsError(t *testing.T) {
+	v := getSharedValidator(t)
+
+	resource := []byte(`{
+	  "resourceType": "Observation",
+	  "status": "final",
+	  "text": {"status": "generated", "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">probe</div>"},
+	  "code": {"coding": [{"system": "http://loinc.org", "display": "d"}]}
+	}`)
+
+	result, err := v.Validate(context.Background(), resource)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	got := issueFor(t, result, issue.DiagCodingNoCode)
+	if got == nil {
+		t.Fatalf("a Coding naming a system with no code must be reported; issues: %v",
+			result.Issues)
+	}
+	if got.Severity != issue.SeverityError {
+		t.Errorf("severity = %s, want %s", got.Severity, issue.SeverityError)
+	}
+	// The system belongs in the message — it says which vocabulary was left unanswered.
+	if !strings.Contains(got.Diagnostics, "http://loinc.org") {
+		t.Errorf("diagnostics = %q, want the system named", got.Diagnostics)
+	}
+	// LOINC is external and unresolvable here, but that is a separate matter: an absent
+	// code is decidable without consulting any terminology source.
+	if issueFor(t, result, issue.DiagBindingCannotValidate) != nil {
+		t.Error("an absent code needs no terminology lookup, so it must not be reported " +
+			"as merely unvalidatable")
+	}
+}
+
+// TestCodeableConceptWithOnlyTextIsSilent guards the boundary. Text alone is a legitimate
+// way to express a concept — FHIR allows it precisely when no code fits — so neither rule
+// may fire when there is no coding at all. The reference is silent here too.
+func TestCodeableConceptWithOnlyTextIsSilent(t *testing.T) {
+	v := getSharedValidator(t)
+
+	resource := []byte(`{
+	  "resourceType": "Observation",
+	  "status": "final",
+	  "text": {"status": "generated", "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">probe</div>"},
+	  "code": {"text": "free text only"}
+	}`)
+
+	result, err := v.Validate(context.Background(), resource)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	for _, id := range []issue.DiagnosticID{issue.DiagCodingNoSystem, issue.DiagCodingNoCode} {
+		if issueFor(t, result, id) != nil {
+			t.Errorf("%s fired on a CodeableConcept with no coding; text alone is valid", id)
+		}
+	}
+}

--- a/pkg/validator/fixtures_test.go
+++ b/pkg/validator/fixtures_test.go
@@ -439,7 +439,7 @@ func TestMixedArrayValidation(t *testing.T) {
 		{
 			name:          "mixed-array-coding",
 			file:          "mixed-array-coding.json",
-			expectedCount: 3, // badField, invalidElement, alsoInvalid
+			expectedCount: 4, // badField, invalidElement, alsoInvalid + coding[3] names a system with no code
 			description:   "Observation.code.coding array with 4 elements: 2 valid, 2 with unknown fields",
 		},
 		{

--- a/testdata/m11-terminology-conformance/invalid-coding-system-without-code.json
+++ b/testdata/m11-terminology-conformance/invalid-coding-system-without-code.json
@@ -1,0 +1,20 @@
+{
+  "resourceType": "Observation",
+  "id": "coding-system-without-code",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">A Coding that names a vocabulary and then says nothing in it</div>"
+  },
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "display": "Body height"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/example"
+  }
+}

--- a/testdata/m11-terminology-conformance/warning-coding-without-system.json
+++ b/testdata/m11-terminology-conformance/warning-coding-without-system.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "Observation",
+  "id": "coding-without-system",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">A Coding that names no system, alongside text that does carry the meaning</div>"
+  },
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "code": "8302-2",
+        "display": "Body height"
+      }
+    ],
+    "text": "Body height"
+  },
+  "subject": {
+    "reference": "Patient/example"
+  }
+}


### PR DESCRIPTION
A `Coding` means something only as a pair. Neither half alone identifies a concept — but until now, missing a half was treated the same as having both: `checkCodingAgainstCodeSystem` returned silently when either was empty, because there was nothing to look up.

Silence was the wrong conclusion. Undecidable is not valid, and this is the same shape of defect as the one fixed in #70 — a question answered by falling through instead of being asked.

## Two cases, two severities

Both follow the reference rather than our own reading:

| Coding | severity | why |
|---|---|---|
| no `system` | **warning** | The code cannot be placed in any vocabulary, but the concept may still be carried by `CodeableConcept.text` — which FHIR allows precisely when no code fits. |
| no `code` | **error** | The instance committed to a vocabulary and then said nothing in it. Nothing downstream can recover from that. |

Both are reported on the Coding itself rather than a child: the defect is the missing half of a pair, not a bad value.

## Verified against HL7 validator_cli 6.9.12

The evidence came from a fixture already in the repo — `testdata/m4-complex/mixed-array-coding.json` happened to contain both shapes, and its expected error count was encoding the gap:

```
coding[2] (code, no system)   HL7: Warning  Coding has no system ...      we: nothing
coding[3] (system, no code)   HL7: Error    has no code for system ...    we: nothing
```

Both now match the reference in severity, path and text, confirmed side by side on two new conformance fixtures:

```
--- HL7:     Warning @ Observation.code.coding[0]  Coding has no system. A code with no system ...
--- ours:    WARN  [processing] Coding has no system. A code with no system ... @ Observation.code.coding[0]

--- HL7:     Error @ Observation.code.coding[0]  Coding has no code for system http://loinc.org ...
--- ours:    ERROR [invalid] Coding has no code for system http://loinc.org ... @ Observation.code.coding[0]
```

## The boundary that matters

A `CodeableConcept` carrying only `text` stays silent, as it does in the reference — text alone is a legitimate way to express a concept. That case has its own test, because it is what keeps these rules from firing on valid data.

One thing worth recording: the reference reports the missing-code error **even when `_code` carries a `data-absent-reason` extension**. I checked that specifically, expecting an exemption; there is none, so the rule is purely structural and this implementation matches.

## Behaviour change

A Coding naming a system with no code is now an error where it previously passed. Hence `feat`, consistent with #70 and `compose.exclude`.

Full suite, `-race` and `golangci-lint` clean. One existing expectation updated, from 3 errors to 4 — the fixture was right and the count was wrong.