### PR TITLE
docs: complete the engine gap inventory, derived from the StructureDefinitions

### DIFF
--- a/docs/plans/2026-07-30-fhirpath-engine-gaps.md
+++ b/docs/plans/2026-07-30-fhirpath-engine-gaps.md
@@ -165,6 +165,23 @@ The ReDoS guard is a good idea, but here it rejects a pattern that ships with th
 specification, so `ElementDefinition.path` cannot be validated at all — which matters for
 anyone validating StructureDefinitions, profiles or IG content.
 
+Confirmed end to end on a StructureDefinition whose differential declares
+`"path": "Patient has spaces, and #bad chars!"`:
+
+```text
+HL7:    Error   @ StructureDefinition.differential.element[1]
+                  Constraint failed: eld-19: 'Element names cannot include some special characters'
+        Warning @ StructureDefinition.differential.element[1]
+                  Constraint failed: eld-20: 'Element names should be simple alphanumerics ...'
+
+ours:   Warning @ StructureDefinition.differential.element[1]
+                  Could not evaluate constraint 'eld-19': potentially dangerous regex
+        Warning @ StructureDefinition.differential.element[1]
+                  Could not evaluate constraint 'eld-20': potentially dangerous regex
+```
+
+The `SHALL`-level `eld-19` never produces a verdict, so a malformed element path passes.
+
 Worth considering: Go's `regexp` is RE2, which has no catastrophic backtracking, so the
 consecutive-quantifier heuristic may be guarding against a risk the underlying engine does
 not carry. If the guard is needed for a non-RE2 path, an allowance for patterns coming from

--- a/docs/plans/2026-07-30-fhirpath-engine-gaps.md
+++ b/docs/plans/2026-07-30-fhirpath-engine-gaps.md
@@ -1,4 +1,4 @@
-# Three gaps in `gofhir/fhirpath` v1.1.0 that block base R4 invariants
+# Engine gaps blocking base R4 invariants — `gofhir/fhirpath` v1.1.0
 
 **For:** the `github.com/gofhir/fhirpath` maintainers
 **From:** the `github.com/gofhir/validator` maintainers
@@ -6,38 +6,59 @@
 **Engine:** `gofhir/fhirpath v1.1.0`
 **Compared against:** HL7 `validator_cli` 6.9.12, FHIR R4 (4.0.1)
 
-None of these are worked around on our side. We report the affected constraints as
-unevaluatable and leave the verdict missing, so fixing them here closes real conformance
+None of these are worked around on our side. Affected constraints are reported as
+unevaluatable and the verdict is left missing, so fixing them here closes real conformance
 gaps rather than changing cosmetics.
 
-Context for why they surfaced now: our constraint engine used to skip any element declaring
-more than one type, which made every constraint of every choice type unreachable — 167
-elements in R4. With that fixed, the constraints below are reached for the first time, and
-these three are what stop them from producing a verdict.
+They surfaced now because our constraint engine used to skip any element declaring more than
+one type, which made every constraint of every choice type unreachable — 167 elements in R4.
+With that fixed, these constraints are reached for the first time.
 
-Good news first: **all 248 distinct constraint expressions in `hl7.fhir.r4.core#4.0.1`
-compile.** Every gap below is in evaluation.
+## How this was measured
+
+`pkg/constraint/enginegaps_test.go` (run with `FPAUDIT=1`) derives everything from the
+StructureDefinitions in the loaded packages — nothing is enumerated by hand, so it stays
+correct across FHIR versions and package sets:
+
+- expressions come from `ElementDefinition.constraint` across all 910 SDs
+- the instances they are evaluated against are built from `ElementDefinition.type`
+- shadowing candidates are found by comparing each element's name against the type
+  containing it
+
+Result: **252 distinct published constraints, 0 compile failures.** Every gap below is in
+evaluation. `FPAUDIT_VERSION=4.3.0` or `5.0.0` re-runs it against R4B or R5.
+
+## Summary
+
+| # | Gap | Constraints affected | Severity |
+| --- | --- | --- | --- |
+| 1 | An element whose name matches its containing type returns the container | `ref-1` | **critical — silent false pass** |
+| 2 | `%ucum` is undefined | `age-1` `cnt-3` `dis-1` `drt-1` `ras-1` | high |
+| 3 | A published FHIR regex is rejected as dangerous | `eld-19` `eld-20` | medium |
+| 4 | Two `Quantity` values cannot be compared | `rng-2` | medium |
 
 ---
 
-## 1. A field named `reference` is not navigated — CRITICAL
+## 1. An element whose name matches its containing type returns the container
 
-Navigating to a field called `reference` returns the **containing object** instead of the
-field's value. Every string function then operates on the object's JSON serialization.
+The engine infers a node's FHIR type from its shape, then treats an identifier matching that
+type name — **case-insensitively, in any position** — as a reference to the node itself
+instead of navigating to a field of that name.
 
-Minimal reproduction, no FHIR types or variables involved:
+In FHIRPath, resolving the type name to the node is correct only for the **capitalised** type
+at the **start** of an expression (`Patient.name`). Applied case-insensitively and at any
+position, the type name shadows any element of the same name.
 
 ```go
 ctx := eval.NewContext([]byte(`{"reference":"#nope"}`))
 expr, _ := fhirpath.Compile(`reference`)
-got, _ := expr.EvaluateWithContext(ctx)
-// got  == [{"reference":"#nope"}]     <- the object
-// want == ["#nope"]                   <- the field value
+// got  == [{"reference":"#nope"}]     <- the container
+// want == ["#nope"]                   <- the element's value
 ```
 
-Observed against `{"reference":"#nope"}`:
+Every string function then operates on the container's JSON:
 
-| Expression | Got | Want |
+| Expression on `{"reference":"#nope"}` | Got | Want |
 | --- | --- | --- |
 | `reference` | `{"reference":"#nope"}` | `"#nope"` |
 | `reference.startsWith('#')` | `false` | `true` |
@@ -45,34 +66,59 @@ Observed against `{"reference":"#nope"}`:
 | `reference.length()` | `21` | `5` |
 | `reference = '#nope'` | `false` | `true` |
 
-`reference.substring(1)` returning `"reference":"#nope"}` is the giveaway: that is the whole
-JSON object with its first character removed.
+`substring(1)` returning `"reference":"#nope"}` is the giveaway — the container minus its
+first character.
 
-**It is the name, not the access path.** The identical shape with any other field name
-works, and the failure follows the name one level down:
+**It is the type name, not that name in particular.** The same shadowing happens for other
+inferred types, and does not happen when the shape does not infer one:
 
 ```
-{"other":"#nope"}          other.startsWith('#')        => true    correct
-{"x":{"reference":"#nope"}} x.reference.startsWith('#')  => false   wrong
+{"start":"2026-01-01","end":"2020-01-01"}  ->  period    => the container   (inferred Period)
+{"start":"2026-01-01","end":"2020-01-01"}  ->  Period    => the container   correct
+{"value":5,"code":"mg","system":"..."}     ->  quantity  => the container   (inferred Quantity)
+{"display":"d"}                            ->  reference => {}              correct
+{"foo":"bar"}                              ->  period    => {}              correct
 ```
 
-So `reference` appears to be treated as reserved — plausibly tied to `resolve()` or to the
-Reference type — and shadows the field of the same name.
+### Scope, measured rather than guessed
 
-**What it breaks.** `ref-1` on the `Reference` type, which is `SHALL`-level:
+Scanning every complex type for elements whose own name matches the type containing them
+yields **exactly three in R4**, of which **one is shadowed**:
+
+| Element | Result |
+| --- | --- |
+| `Reference.reference` | **shadowed** |
+| `Extension.extension` | navigates correctly |
+| `Expression.expression` | navigates correctly |
+
+We checked specifically that `ext-1` (`extension.exists() != value.exists()`) is **not**
+affected, and that `tim-5` evaluates correctly against real `Timing.repeat` data — the two
+places we expected collateral damage and did not find it.
+
+### What it breaks
+
+`ref-1` on the `Reference` type, `SHALL`-level:
 
 ```
 ref-1: SHALL have a contained resource if a local reference is provided
   reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))
 ```
 
-`startsWith('#')` returns `false`, so `.not()` returns `true`, so the whole disjunction is
-`true` and **`ref-1` can never fail** — a silent false pass on every `Reference` in every
-resource. Confirmed end to end: a `Patient.managingOrganization` of `#nope` with no matching
-contained resource is reported by HL7 as a `ref-1` failure and passes for us.
+`startsWith('#')` returns `false`, so `.not()` returns `true`, so the disjunction
+short-circuits `true` and **`ref-1` can never fail** — on every `Reference` in every
+resource. Confirmed end to end: `Patient.managingOrganization` of `#nope` with no matching
+contained resource is a `ref-1` failure in HL7 and passes for us.
 
-`Reference` appears in 70 choice elements alone, plus every single-typed reference element
-in R4.
+This is worse than an error: no diagnostic says the check did not happen. Sweeping the
+official example corpus makes it visible through the constraint's own `trace()`, which prints
+the container instead of the id, thousands of times:
+
+```text
+[trace] url: ["\"reference\":\"Patient/example\"}"]
+[trace] url: ["\"display\":\"Dr Adam Careful\",\"reference\":\"Practitioner/example\"}"]
+```
+
+Each of those should have been a bare id.
 
 ---
 
@@ -84,12 +130,12 @@ InvalidPathError: undefined variable: %ucum
 
 `%ucum` is an environment constant the FHIR specification defines for FHIRPath
 (`http://unitsofmeasure.org`), alongside `%resource` / `%rootResource` / `%context`. We wire
-those three explicitly; `%ucum` is a fixed constant with no caller input, so it belongs with
-the engine's FHIR context rather than being injected per call by each consumer.
+those three explicitly, but `%ucum` is a fixed constant with no caller input, so it belongs
+with the engine's FHIR context rather than being injected per call by every consumer.
 
-Five base R4 invariants depend on it, all `SHALL`-level:
+Five `SHALL`-level invariants depend on it:
 
-| Key | Type | Expression fragment |
+| Key | Type | Fragment |
 | --- | --- | --- |
 | `age-1` | Age | `(system.empty() or system = %ucum)` |
 | `drt-1` | Duration | `code.exists() implies ((system = %ucum) and value.exists())` |
@@ -97,18 +143,42 @@ Five base R4 invariants depend on it, all `SHALL`-level:
 | `dis-1` | Distance | `(system.empty() or system = %ucum)` |
 | `ras-1` | RiskAssessment.prediction.probability[x] | `low.system = %ucum` |
 
-Confirmed end to end: a `Condition.onsetAge` with `system` set to something other than UCUM
-is an `age-1` error in HL7, and for us an unevaluatable-constraint warning.
+Confirmed end to end: a `Condition.onsetAge` whose `system` is not UCUM is an `age-1` error
+in HL7, and an unevaluatable-constraint warning for us.
 
 ---
 
-## 3. Two `Quantity` values cannot be compared
+## 3. A published FHIR regex is rejected as dangerous
+
+```
+InvalidExpressionError: potentially dangerous regex: consecutive quantifiers
+```
+
+Affects `eld-19` and `eld-20` on `ElementDefinition`, whose patterns are published by HL7 in
+the R4 specification itself:
+
+```
+eld-19: path.matches('[^\s\.,:;\'"\/|?!@#$%&*()\[\]{}]{1,64}(\.[^\s\.,:;\'"\/|?!@#$%&*()\[\]{}]{1,64}(\[x\])?(\:[^\s\.]+)?)*')
+```
+
+The ReDoS guard is a good idea, but here it rejects a pattern that ships with the
+specification, so `ElementDefinition.path` cannot be validated at all — which matters for
+anyone validating StructureDefinitions, profiles or IG content.
+
+Worth considering: Go's `regexp` is RE2, which has no catastrophic backtracking, so the
+consecutive-quantifier heuristic may be guarding against a risk the underlying engine does
+not carry. If the guard is needed for a non-RE2 path, an allowance for patterns coming from
+loaded StructureDefinitions would keep the specification's own regexes working.
+
+---
+
+## 4. Two `Quantity` values cannot be compared
 
 ```
 InvalidOperationError: cannot apply 'compare' to Quantity and Quantity
 ```
 
-Breaks `rng-2` on the `Range` type, also `SHALL`-level:
+Breaks `rng-2` on `Range`, `SHALL`-level:
 
 ```
 rng-2: If present, low SHALL have a lower value than high
@@ -116,31 +186,43 @@ rng-2: If present, low SHALL have a lower value than high
 ```
 
 `Range.low` and `Range.high` are `SimpleQuantity`, so this comparison is the entire point of
-the invariant and it cannot currently be evaluated at all. Confirmed end to end on
+the invariant. Confirmed end to end on
 `MedicationRequest.dosageInstruction[0].doseAndRate[0].doseRange` with `low` 10 mg and `high`
 2 mg: HL7 reports `rng-2`, we report that we could not evaluate it.
 
-`Range` appears in 27 choice elements including `Condition.onset[x]` and
-`Observation.value[x]`.
-
-Note this one has real depth to it — comparing quantities properly means comparing
-commensurable units, not just the `value` fields, so `10 mg <= 2 g` should hold. Comparing
-`value` only when `code`/`system` are equal, and returning empty otherwise, would already
-make `rng-2` decidable in the common case without claiming unit conversion.
+This one has real depth — comparing quantities properly means comparing commensurable units,
+so `10 mg <= 2 g` should hold, which is `gofhir/ucum` territory. Comparing `value` only when
+`code` and `system` match, and returning empty otherwise, would already make `rng-2`
+decidable in the common case without claiming unit conversion.
 
 ---
 
 ## Priority
 
-1. **`reference` field navigation** — a silent false pass, which is worse than an error: no
-   diagnostic tells anyone the check did not happen. It also has the widest blast radius,
-   since it affects any expression touching a field of that name, not only `ref-1`.
+1. **Type-name shadowing** — a silent false pass on every `Reference`, and no diagnostic
+   admits it. The narrow fix is to resolve a type name to the node only when capitalised and
+   at the start of an expression.
 2. **`%ucum`** — five invariants, and the fix is a constant.
-3. **`Quantity` comparison** — one invariant, and the correct fix needs unit handling.
+3. **The regex guard** — two invariants, and it blocks patterns the specification publishes.
+4. **`Quantity` comparison** — one invariant; the correct fix needs unit handling.
 
-## Reproducing
+## `gofhir/ucum` — audited, no defects found
 
-Expressions were extracted from `hl7.fhir.r4.core-4.0.1.tgz` (248 distinct key+expression
-pairs across all StructureDefinitions) and compiled with `fhirpath.Compile`; all 248 passed.
-The evaluation failures above were then narrowed to the minimal cases shown, each of which
-runs against the engine directly with no dependency on our validator.
+Worth recording since it was checked at the same time. Thirty UCUM codes through
+`pkg/ucumvalidator`, compared against HL7:
+
+- 20 valid codes accepted, including `mm[Hg]`, `10*3/uL`, `{beats}/min`, `k[IU]/L`, `g/(24.h)`
+- 8 invalid codes rejected: `mmHg`, `degF`, `foo`, `mg/`, `mg dL`, `[bogus]`, `mg**2`, `//min`
+- **Two of our own expectations were wrong, not the library**: `10^3/uL` and `MG` are valid
+  (UCUM defines `10^` alongside `10*`, and `G` is gauss, so `MG` is megagauss). The library
+  and HL7 both accept them; only our test expectation was mistaken.
+
+One divergence, where the library appears **more correct than the reference**: `//min` is
+rejected by us and accepted by HL7. The UCUM grammar allows a leading solidus (`/min`) but
+not two, and the library's message names the position precisely (`unexpected token "/"
+(solidus)`). No change requested.
+
+Separately, this audit turned up something of ours rather than the library's: an invalid UCUM
+code is a **warning** for us and an **error** in HL7. Since `system` is
+`http://unitsofmeasure.org` and the code does not exist in it, this is the same rule we made
+an error in #70 — a code absent from the CodeSystem the instance names. Tracked on our side.

--- a/pkg/constraint/enginegaps_test.go
+++ b/pkg/constraint/enginegaps_test.go
@@ -1,0 +1,341 @@
+package constraint_test
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gofhir/fhirpath"
+	"github.com/gofhir/fhirpath/eval"
+
+	"github.com/gofhir/validator/pkg/loader"
+	"github.com/gofhir/validator/pkg/registry"
+	"github.com/gofhir/validator/pkg/specs"
+)
+
+// Engine gap audit.
+//
+// Everything here is derived from the StructureDefinitions in the loaded packages: the
+// expressions come from ElementDefinition.constraint, the instances are built from
+// ElementDefinition.type, and the shadowing candidates are found by comparing element names
+// against the type that contains them. Nothing is enumerated by hand, so the audit stays
+// correct across FHIR versions and package sets.
+//
+// Skipped unless FPAUDIT is set, so it never runs in CI.
+
+func auditRegistry(t *testing.T) *registry.Registry {
+	t.Helper()
+	version := os.Getenv("FPAUDIT_VERSION")
+	if version == "" {
+		version = "4.0.1"
+	}
+	l := loader.NewLoader("")
+	packages, err := l.LoadFromEmbeddedData(specs.GetPackages(version))
+	if err != nil {
+		t.Fatalf("load packages for %s: %v", version, err)
+	}
+	reg := registry.New()
+	if err := reg.LoadFromPackages(packages); err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+	t.Logf("registry: %d StructureDefinitions, %d types (FHIR %s)", reg.Count(), reg.TypeCount(), version)
+	return reg
+}
+
+// constraintEntry is one constraint as published, with where it came from.
+type constraintEntry struct {
+	key, expr, path, sd string
+}
+
+// collectConstraints walks every StructureDefinition in the registry and returns each
+// distinct (key, expression) pair. Read from the SDs, not from a fixed list.
+func collectConstraints(reg *registry.Registry) []constraintEntry {
+	seen := map[string]bool{}
+	var out []constraintEntry
+	for _, url := range reg.AllURLs() {
+		sd := reg.GetByURL(url)
+		if sd == nil || sd.Snapshot == nil {
+			continue
+		}
+		for i := range sd.Snapshot.Element {
+			elem := &sd.Snapshot.Element[i]
+			for j := range elem.Constraint {
+				c := &elem.Constraint[j]
+				if c.Expression == "" {
+					continue
+				}
+				k := c.Key + "\x00" + c.Expression
+				if seen[k] {
+					continue
+				}
+				seen[k] = true
+				name := sd.Type
+				if name == "" {
+					name = sd.ID
+				}
+				out = append(out, constraintEntry{key: c.Key, expr: c.Expression, path: elem.Path, sd: name})
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].key < out[j].key })
+	return out
+}
+
+// syntheticInstance builds a JSON object for a type using its own ElementDefinitions:
+// each direct child is populated with a value of the type the SD declares. The depth
+// argument bounds recursion into complex children.
+func syntheticInstance(reg *registry.Registry, sd *registry.StructureDefinition, depth int) string {
+	if sd == nil || sd.Snapshot == nil || depth < 0 {
+		return "{}"
+	}
+	typeName := sd.Type
+	if typeName == "" {
+		typeName = sd.ID
+	}
+
+	var fields []string
+	for i := range sd.Snapshot.Element {
+		elem := &sd.Snapshot.Element[i]
+		// direct children only
+		rest := strings.TrimPrefix(elem.Path, typeName+".")
+		if rest == elem.Path || strings.Contains(rest, ".") {
+			continue
+		}
+		if len(elem.Type) == 0 || elem.Max == "0" {
+			continue
+		}
+		if rest == "id" || rest == "extension" || rest == "modifierExtension" {
+			continue
+		}
+		typeCode := elem.Type[0].Code
+		name := rest
+		if strings.HasSuffix(rest, "[x]") {
+			name = strings.TrimSuffix(rest, "[x]") + strings.ToUpper(typeCode[:1]) + typeCode[1:]
+		}
+		val := syntheticValue(reg, typeCode, depth)
+		if val == "" {
+			continue
+		}
+		if elem.Max == "*" {
+			val = "[" + val + "]"
+		}
+		fields = append(fields, fmt.Sprintf("%q:%s", name, val))
+	}
+	sort.Strings(fields)
+	return "{" + strings.Join(fields, ",") + "}"
+}
+
+// syntheticValue renders a value for one type code, using the registry to tell primitives
+// from complex types rather than a hardcoded type list.
+func syntheticValue(reg *registry.Registry, typeCode string, depth int) string {
+	typeSD := reg.GetByType(typeCode)
+	if typeSD != nil && typeSD.Kind == "complex-type" {
+		if depth <= 0 {
+			return ""
+		}
+		return syntheticInstance(reg, typeSD, depth-1)
+	}
+	// Primitives: the JSON form follows the primitive's own base type in the SD.
+	base := typeCode
+	if typeSD != nil && typeSD.Snapshot != nil {
+		for i := range typeSD.Snapshot.Element {
+			e := &typeSD.Snapshot.Element[i]
+			if e.Path == typeCode+".value" && len(e.Type) > 0 {
+				if ext := e.Type[0].Code; ext != "" {
+					base = ext
+				}
+				break
+			}
+		}
+	}
+	switch base {
+	case "boolean", "http://hl7.org/fhirpath/System.Boolean":
+		return "true"
+	case "integer", "positiveInt", "unsignedInt", "http://hl7.org/fhirpath/System.Integer":
+		return "1"
+	case "decimal", "http://hl7.org/fhirpath/System.Decimal":
+		return "1"
+	case "http://hl7.org/fhirpath/System.DateTime", "dateTime", "date", "instant":
+		return `"2026-01-01"`
+	case "http://hl7.org/fhirpath/System.Time", "time":
+		return `"12:00:00"`
+	default:
+		return `"x"`
+	}
+}
+
+// TestAuditEngineExpressionGaps compiles and evaluates every published constraint expression
+// against instances built from the SDs, and groups whatever the engine cannot handle.
+func TestAuditEngineExpressionGaps(t *testing.T) {
+	if os.Getenv("FPAUDIT") == "" {
+		t.Skip("set FPAUDIT=1 to run the engine gap audit")
+	}
+	reg := auditRegistry(t)
+	entries := collectConstraints(reg)
+	t.Logf("distinct published constraints: %d", len(entries))
+
+	// One instance per type that declares constraints, built from that type's own SD, plus
+	// the empty object so expressions that need no operands are still exercised.
+	shapes := map[string]string{"empty": "{}"}
+	for _, e := range entries {
+		if _, ok := shapes[e.sd]; ok {
+			continue
+		}
+		if sd := reg.GetByType(e.sd); sd != nil {
+			shapes[e.sd] = syntheticInstance(reg, sd, 2)
+		}
+	}
+	t.Logf("synthetic instances built from SDs: %d", len(shapes)-1)
+
+	type failure struct{ key, sd, path, shape, expr, err string }
+	var compileFails, evalFails []failure
+	seen := map[string]bool{}
+
+	for _, e := range entries {
+		expr, cerr := fhirpath.Compile(e.expr)
+		if cerr != nil {
+			compileFails = append(compileFails, failure{e.key, e.sd, e.path, "-", e.expr, cerr.Error()})
+			continue
+		}
+		// Evaluate against the instance of its own type first, then every other shape.
+		order := make([]string, 0, 2+len(shapes))
+		order = append(order, e.sd, "empty")
+		for name := range shapes {
+			order = append(order, name)
+		}
+		for _, shapeName := range order {
+			shape, ok := shapes[shapeName]
+			if !ok {
+				continue
+			}
+			ctx := eval.NewContext([]byte(shape))
+			if _, eerr := expr.EvaluateWithContext(ctx); eerr != nil {
+				k := e.key + "|" + eerr.Error()
+				if seen[k] {
+					continue
+				}
+				seen[k] = true
+				evalFails = append(evalFails, failure{e.key, e.sd, e.path, shapeName, e.expr, eerr.Error()})
+			}
+		}
+	}
+
+	t.Logf("=== compile failures: %d", len(compileFails))
+	for _, f := range compileFails {
+		t.Logf("  [%s] %s.%s: %s", f.key, f.sd, f.path, f.err)
+		t.Logf("      expr: %s", f.expr)
+	}
+
+	// Group evaluation failures by error class.
+	byClass := map[string][]failure{}
+	for _, f := range evalFails {
+		cls := f.err
+		if i := strings.Index(cls, " ("); i > 0 {
+			cls = cls[:i]
+		}
+		byClass[cls] = append(byClass[cls], f)
+	}
+	classes := make([]string, 0, len(byClass))
+	for c := range byClass {
+		classes = append(classes, c)
+	}
+	sort.Slice(classes, func(i, j int) bool { return len(byClass[classes[i]]) > len(byClass[classes[j]]) })
+
+	t.Logf("=== evaluation failure classes: %d", len(classes))
+	for _, c := range classes {
+		keys := map[string]bool{}
+		for _, f := range byClass[c] {
+			keys[f.key] = true
+		}
+		kl := make([]string, 0, len(keys))
+		for k := range keys {
+			kl = append(kl, k)
+		}
+		sort.Strings(kl)
+		f := byClass[c][0]
+		t.Logf("CLASS %s", c)
+		t.Logf("      affects %d constraints: %s", len(kl), strings.Join(kl, " "))
+		t.Logf("      example: [%s] %s.%s on the %s instance", f.key, f.sd, f.path, f.shape)
+		t.Logf("      expr: %s", f.expr)
+	}
+}
+
+// TestAuditTypeNameShadowing finds every element whose own name matches the type that
+// contains it — the shape that triggers the engine's type-name shadowing — by scanning the
+// SDs, then checks whether navigating to that element returns its value or the container.
+func TestAuditTypeNameShadowing(t *testing.T) {
+	if os.Getenv("FPAUDIT") == "" {
+		t.Skip("set FPAUDIT=1 to run the engine gap audit")
+	}
+	reg := auditRegistry(t)
+
+	// Candidates: element <T>.<name> where lower(name) == lower(T).
+	type candidate struct{ typeName, field, typeCode string }
+	var candidates []candidate
+	// Deduplicate by type+field: the packages carry hundreds of extension profiles, all of
+	// them type Extension with an `extension` element, and they are all the same case.
+	dedupe := map[string]bool{}
+	for _, url := range reg.AllURLs() {
+		sd := reg.GetByURL(url)
+		if sd == nil || sd.Snapshot == nil || sd.Kind != "complex-type" {
+			continue
+		}
+		typeName := sd.Type
+		if typeName == "" {
+			typeName = sd.ID
+		}
+		for i := range sd.Snapshot.Element {
+			elem := &sd.Snapshot.Element[i]
+			rest := strings.TrimPrefix(elem.Path, typeName+".")
+			if rest == elem.Path || strings.Contains(rest, ".") || len(elem.Type) == 0 {
+				continue
+			}
+			if strings.EqualFold(rest, typeName) {
+				k := typeName + "." + rest
+				if dedupe[k] {
+					continue
+				}
+				dedupe[k] = true
+				candidates = append(candidates, candidate{typeName, rest, elem.Type[0].Code})
+			}
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].typeName < candidates[j].typeName })
+	t.Logf("=== elements whose name matches their containing type: %d", len(candidates))
+
+	bad := 0
+	for _, c := range candidates {
+		sd := reg.GetByType(c.typeName)
+		instance := syntheticInstance(reg, sd, 2)
+		expr, err := fhirpath.Compile(c.field)
+		if err != nil {
+			t.Logf("!! %s.%s COMPILE %v", c.typeName, c.field, err)
+			bad++
+			continue
+		}
+		ctx := eval.NewContext([]byte(instance))
+		got, err := expr.EvaluateWithContext(ctx)
+		if err != nil {
+			t.Logf("!! %s.%s EVAL ERROR %v", c.typeName, c.field, err)
+			bad++
+			continue
+		}
+		rendered := "{}"
+		if !got.Empty() {
+			rendered = got[0].String()
+		}
+		// Shadowing shows up as the navigation returning the whole container.
+		shadowed := strings.HasPrefix(rendered, "{") && strings.Contains(rendered, `"`+c.field+`"`)
+		mark := "  "
+		if shadowed {
+			mark = "!!"
+			bad++
+		}
+		t.Logf("%s %s.%s (%s)", mark, c.typeName, c.field, c.typeCode)
+		t.Logf("      instance: %s", instance)
+		t.Logf("      %q => %s", c.field, rendered)
+	}
+	t.Logf("=== %d of %d shadowed", bad, len(candidates))
+}


### PR DESCRIPTION
The first version of this report was assembled by hand — a Python script dumping expressions to JSON, and a list of field names I picked myself. That is the opposite of how this project works, and it also got the root cause wrong.

The audit now lives in [pkg/constraint/enginegaps_test.go](pkg/constraint/enginegaps_test.go) and derives everything from the loaded packages:

- expressions from `ElementDefinition.constraint` across all 910 SDs
- the instances they are evaluated against, built from `ElementDefinition.type`
- shadowing candidates, from comparing each element's name against the type containing it

Nothing is enumerated by hand, so it stays correct across versions — `FPAUDIT_VERSION=4.3.0` re-runs it on R4B. Gated behind `FPAUDIT` so CI never runs it.

**252 distinct published constraints, 0 compile failures, 4 gaps affecting 9 constraints.**

## Root cause corrected

`reference` is **not** a reserved word. The engine infers a node's type from its shape, then resolves an identifier matching that type name — **case-insensitively, in any position** — to the node itself. FHIRPath permits that only for the capitalised type at the *start* of an expression.

```
{"start":"2026-01-01","end":"2020-01-01"}  ->  period    => the container   (inferred Period)
{"value":5,"code":"mg","system":"..."}     ->  quantity  => the container   (inferred Quantity)
{"display":"d"}                            ->  reference => {}              correct
{"foo":"bar"}                              ->  period    => {}              correct
```

Scanning every complex type for elements whose name matches their container gives **exactly three in R4**, of which **one** is shadowed:

| Element | Result |
| --- | --- |
| `Reference.reference` | **shadowed** → `ref-1` can never fail |
| `Extension.extension` | correct → `ext-1` unaffected, checked specifically |
| `Expression.expression` | correct |

## One gap is new

The engine rejects the regex in `eld-19`/`eld-20` as `potentially dangerous regex: consecutive quantifiers` — but HL7 publishes that pattern in the R4 specification itself, so `ElementDefinition.path` cannot be validated at all. Go's `regexp` is RE2 and has no catastrophic backtracking, so the heuristic may be guarding a risk this engine does not carry.

## One earlier finding was mine, not the engine's

`tim-5` failing to compare `Period` with `Integer` came from my method evaluating a Timing constraint against a `CarePlan` instance, which has a real `period` element of type Period. Against real `Timing.repeat` data it evaluates correctly. Removed from the report.

## `gofhir/ucum` — audited, no defects found

30 codes through `pkg/ucumvalidator`, compared against HL7: 20 valid accepted (`mm[Hg]`, `10*3/uL`, `{beats}/min`, `g/(24.h)`…), 8 invalid rejected.

**Two of my expectations were wrong rather than the library**: `10^3/uL` and `MG` are valid — UCUM defines `10^` alongside `10*`, and `G` is gauss, so `MG` is megagauss. Both the library and HL7 accept them.

One divergence where the library is **more correct than the reference**: `//min` is rejected by us and accepted by HL7. The UCUM grammar allows one leading solidus, not two, and the library's message names the position precisely. No change requested.

## And one of ours, for follow-up

That audit surfaced a gap on our side: an invalid UCUM code is a **warning** for us and an **error** in HL7. Since `system` is `http://unitsofmeasure.org` and the code does not exist in it, this is the same rule we made an error in #70 — a code absent from the CodeSystem the instance names. Not fixed here.

Docs plus an audit tool. No behaviour changes.