### PR TITLE
feat(ucum): report an invalid UCUM code as an error, not a warning

### DIFF
--- a/pkg/issue/diagnostics.go
+++ b/pkg/issue/diagnostics.go
@@ -430,9 +430,14 @@ var diagnosticTemplates = map[DiagnosticID]DiagnosticTemplate{
 	},
 
 	// UCUM validation.
+	//
+	// An error, not a warning: the instance names http://unitsofmeasure.org as its system and
+	// the code does not exist there, which is the same rule as DiagCodeNotInCodeSystem — a
+	// code absent from the CodeSystem the instance declares. The reference agrees, reporting
+	// "Unknown code 'mmHg' in the CodeSystem 'http://unitsofmeasure.org'".
 	DiagUCUMInvalidCode: {
-		Severity: SeverityWarning,
-		Code:     CodeValue,
+		Severity: SeverityError,
+		Code:     CodeInvalid,
 		Template: "Invalid UCUM code '{code}': {error}",
 	},
 }

--- a/pkg/ucumvalidator/ucumvalidator.go
+++ b/pkg/ucumvalidator/ucumvalidator.go
@@ -125,7 +125,7 @@ func (v *Validator) validateQuantity(data map[string]any, fhirPath string, resul
 	}
 
 	if err := v.ucum.Validate(code); err != nil {
-		result.AddWarningWithID(
+		result.AddErrorWithID(
 			issue.DiagUCUMInvalidCode,
 			map[string]any{"code": code, "error": err.Error()},
 			fhirPath+".code",

--- a/pkg/validator/ucum_test.go
+++ b/pkg/validator/ucum_test.go
@@ -58,13 +58,16 @@ func TestUCUMInvalidQuantityCode(t *testing.T) {
 			continue
 		}
 		found = true
-		if iss.Severity != issue.SeverityWarning {
-			t.Errorf("Expected warning severity, got %s", iss.Severity)
+		// An error rather than a warning: the instance names UCUM as its system and the code
+		// does not exist there, which is the same rule as a code absent from any other
+		// CodeSystem the instance declares. The reference reports it as an error too.
+		if iss.Severity != issue.SeverityError {
+			t.Errorf("Expected error severity, got %s", iss.Severity)
 		}
 		if len(iss.Expression) == 0 {
 			t.Error("Expected expression path")
 		}
-		t.Logf("UCUM warning: %s @ %v", iss.Diagnostics, iss.Expression)
+		t.Logf("UCUM error: %s @ %v", iss.Diagnostics, iss.Expression)
 		break
 	}
 	if !found {


### PR DESCRIPTION
A `Quantity` naming `http://unitsofmeasure.org` as its system and carrying a code that does not exist in UCUM is **the same defect** as a code absent from any other CodeSystem an instance declares — the rule we made an error in #70. It was still a warning here, so the two paths disagreed about the same question depending on which vocabulary was involved.

## The reference agrees

```
HL7:     Error @ Observation.value.ofType(Quantity).code
                 Unknown code 'mmHg' in the CodeSystem 'http://unitsofmeasure.org' version '2.2'
before:  WARN  [value]   Invalid UCUM code 'mmHg' ...
now:     ERROR [invalid] Invalid UCUM code 'mmHg' ...
```

The issue code moves from `CodeValue` to `CodeInvalid` for the same reason: the value is not merely questionable, it does not exist in the system the instance named.

## Scope is unchanged and already correct

The check only runs when `system` is exactly the UCUM canonical, so a `Quantity` with any other system, or with none, is untouched. All 20 valid codes from the audit still report nothing — including `mm[Hg]`, `10*3/uL`, `{beats}/min`, `k[IU]/L` and `g/(24.h)`.

## Where it came from

Found while auditing `gofhir/ucum` against the reference (#77). The library itself turned out to have **no defects** across 30 codes — two apparent failures were my own expectations being wrong, and one case (`//min`) is where the library is stricter than HL7 and right. The only thing that audit surfaced was this inconsistency of ours.

Behaviour change: a resource with a malformed UCUM code now fails where it previously warned. Hence `feat`.

Full suite and `golangci-lint` clean; one test updated, which was asserting the old severity.