### PR TITLE
fix(contained): resolve a fragment deterministically and report a duplicate id

### DIFF
--- a/pkg/issue/diagnostics.go
+++ b/pkg/issue/diagnostics.go
@@ -18,6 +18,7 @@ const (
 	DiagStructureInvalidChoiceType     DiagnosticID = "STRUCTURE_INVALID_CHOICE_TYPE"
 	DiagStructureChoiceMutualExclusion DiagnosticID = "STRUCTURE_CHOICE_MUTUAL_EXCLUSION"
 	DiagStructureNoType                DiagnosticID = "STRUCTURE_NO_TYPE"
+	DiagContainedDuplicateID           DiagnosticID = "CONTAINED_DUPLICATE_ID"
 )
 
 // Diagnostic IDs for cardinality validation (M2).
@@ -146,6 +147,11 @@ var diagnosticTemplates = map[DiagnosticID]DiagnosticTemplate{
 		Severity: SeverityError,
 		Code:     CodeStructure,
 		Template: "Missing 'resourceType' property",
+	},
+	DiagContainedDuplicateID: {
+		Severity: SeverityError,
+		Code:     CodeInvalid,
+		Template: "Duplicate ID for contained resource: {id}",
 	},
 	DiagStructureUnknownResource: {
 		Severity: SeverityError,

--- a/pkg/reference/reference.go
+++ b/pkg/reference/reference.go
@@ -86,6 +86,15 @@ func NewContainedContext(resource map[string]any) *ContainedContext {
 			continue
 		}
 
+		// First occurrence wins. When two contained resources share an id the fragment is
+		// ambiguous, and overwriting made the *last* one resolve — so a reference could be
+		// reported as pointing at the wrong type while the real defect, the repeated id,
+		// went unmentioned. Document order is the one deterministic choice available, and
+		// it is what the reference resolves to.
+		if _, seen := ctx.IDIndex[id]; seen {
+			continue
+		}
+
 		rt, _ := m["resourceType"].(string)
 		ctx.IDIndex[id] = rt
 	}

--- a/pkg/structural/structural.go
+++ b/pkg/structural/structural.go
@@ -420,10 +420,32 @@ func (v *Validator) validateChildren(
 
 // validateContainedResources validates each contained resource against its own StructureDefinition.
 func (v *Validator) validateContainedResources(contained []any, baseFhirPath string, result *issue.Result) {
+	// Ids must be distinct for a fragment reference to identify anything. FHIR R4
+	// §3.1.0.1.10 defines resolution as "internal fragment references (start with '#') refer
+	// to contained resources" — a single one — so two contained resources sharing an id make
+	// every reference to it undecidable.
+	//
+	// This is prose rather than an invariant: no dom-* constraint covers uniqueness, and the
+	// rule is not expressible through a StructureDefinition. Same situation as the absolute-URI
+	// requirement on Extension.url in pkg/extension.
+	seenIDs := make(map[string]struct{}, len(contained))
+
 	for i, item := range contained {
 		resourceMap, ok := item.(map[string]any)
 		if !ok {
 			continue
+		}
+
+		if id, _ := resourceMap["id"].(string); id != "" {
+			if _, dup := seenIDs[id]; dup {
+				result.AddErrorWithID(
+					issue.DiagContainedDuplicateID,
+					map[string]any{"id": id},
+					fmt.Sprintf("%s[%d]", baseFhirPath, i),
+				)
+			} else {
+				seenIDs[id] = struct{}{}
+			}
 		}
 
 		resourceType, _ := resourceMap["resourceType"].(string)

--- a/pkg/validator/contained_test.go
+++ b/pkg/validator/contained_test.go
@@ -1,0 +1,103 @@
+package validator
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gofhir/validator/pkg/issue"
+)
+
+// containedDupID has two contained resources sharing an id, referenced from an element whose
+// allowed target type matches only the first of them. That combination is what made the old
+// behavior report the wrong defect.
+const containedDupID = `{
+  "resourceType": "Patient",
+  "id": "p",
+  "text": {"status": "generated", "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">probe</div>"},
+  "contained": [
+    {"resourceType": "Organization", "id": "same", "name": "First"},
+    {"resourceType": "Practitioner", "id": "same"}
+  ],
+  "managingOrganization": {"reference": "#same"},
+  "generalPractitioner": [{"reference": "#same"}]
+}`
+
+// TestDuplicateContainedIDIsReported covers the defect itself. Ids have to be distinct for a
+// fragment reference to identify anything, and the reference reports it at the same path.
+func TestDuplicateContainedIDIsReported(t *testing.T) {
+	v := getSharedValidator(t)
+
+	result, err := v.Validate(context.Background(), []byte(containedDupID))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	got := issueFor(t, result, issue.DiagContainedDuplicateID)
+	if got == nil {
+		t.Fatalf("two contained resources sharing an id must be reported; issues: %v", result.Issues)
+	}
+	if got.Severity != issue.SeverityError {
+		t.Errorf("severity = %s, want %s", got.Severity, issue.SeverityError)
+	}
+	// Reported on the second occurrence, as the reference does: the first is what every
+	// reference resolves to, so it is the repeat that is wrong.
+	if len(got.Expression) == 0 || !strings.HasSuffix(got.Expression[0], ".contained[1]") {
+		t.Errorf("expression = %v, want the repeated occurrence at contained[1]", got.Expression)
+	}
+}
+
+// TestContainedFragmentResolvesToFirstOccurrence is the half that matters more, because the
+// old behavior did not merely stay silent — it reported a defect that was not there.
+//
+// The index was built by overwriting, so `#same` resolved to the *last* contained resource, a
+// Practitioner, and managingOrganization was reported as pointing at a disallowed type. The
+// real defect went unmentioned and an invented one took its place.
+func TestContainedFragmentResolvesToFirstOccurrence(t *testing.T) {
+	v := getSharedValidator(t)
+
+	result, err := v.Validate(context.Background(), []byte(containedDupID))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	for _, is := range result.Issues {
+		if is.MessageID != string(issue.DiagReferenceInvalidTarget) &&
+			is.MessageID != string(issue.DiagReferenceTypeMismatch) {
+			continue
+		}
+		for _, expr := range is.Expression {
+			if strings.Contains(expr, "managingOrganization") {
+				t.Errorf("managingOrganization resolves to contained[0], an Organization, which is "+
+					"allowed; got %s: %s", is.MessageID, is.Diagnostics)
+			}
+		}
+	}
+}
+
+// TestDistinctContainedIDsAreSilent guards the boundary: contained resources are entirely
+// normal, and only a repeated id is a problem.
+func TestDistinctContainedIDsAreSilent(t *testing.T) {
+	v := getSharedValidator(t)
+
+	resource := []byte(`{
+	  "resourceType": "Patient",
+	  "id": "p",
+	  "text": {"status": "generated", "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">probe</div>"},
+	  "contained": [
+	    {"resourceType": "Organization", "id": "org", "name": "First"},
+	    {"resourceType": "Practitioner", "id": "prac"}
+	  ],
+	  "managingOrganization": {"reference": "#org"},
+	  "generalPractitioner": [{"reference": "#prac"}]
+	}`)
+
+	result, err := v.Validate(context.Background(), resource)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	if issueFor(t, result, issue.DiagContainedDuplicateID) != nil {
+		t.Errorf("distinct ids must not be reported; issues: %v", result.Issues)
+	}
+}


### PR DESCRIPTION
Two contained resources sharing an id caused two separate problems, and the second was worse than silence.

## The invented defect

`NewContainedContext` built its index by overwriting, so `#same` resolved to the **last** contained resource carrying that id. On a Patient with contained `Organization/same` and `Practitioner/same`:

```
before:  ERROR  Invalid reference target type 'Practitioner'. Allowed: Organization
                @ Patient.managingOrganization.reference
```

That defect **does not exist** — the reference is satisfiable by the Organization — while the real one, the repeated id, went unmentioned. We reported a fiction and hid the fact.

First occurrence now wins: document order is the one deterministic choice available, and it is what the reference resolves to.

## The real defect

Ids must be distinct for a fragment to identify anything. R4 §3.1.0.1.10 defines resolution as *"internal fragment references (start with '#') refer to contained resources"* — a single one — so a shared id makes every reference to it undecidable.

This is **prose rather than an invariant**: no `dom-*` constraint covers uniqueness and it is not expressible through a StructureDefinition. Same situation as the absolute-URI requirement on `Extension.url` already in [pkg/extension](pkg/extension/extension.go), so it follows that precedent rather than inventing a pattern.

Matches the reference exactly, path included:

```
HL7:   Error @ Patient.contained[1]   Duplicate ID for contained resource: same
ours:  ERROR   Patient.contained[1]   Duplicate ID for contained resource: same
```

Reported on the **second** occurrence, since the first is what references resolve to. The invented target-type error disappears in the same change.

## What was checked and needs nothing

While auditing `contained` I extracted the constraints from the embedded `.tgz` and verified each against the reference: **`dom-2`, `dom-3`, `dom-4` and `dom-5` all evaluate correctly**, same text and severity.

That settles `GO-GAP-007` (unreferenced contained resources) — **not a gap**. `dom-3` already covers it, derived from the StructureDefinition as it should be. I was about to implement it by hand before checking.

Three tests: the duplicate is reported at the right index and severity, `managingOrganization` no longer draws a target-type error, and distinct ids stay silent.

Full suite and `golangci-lint` clean.