### PR TITLE
feat(deps): bump gofhir/fhirpath to v1.4.0, activating ref-1

### DIFF
--- a/docs/VALIDATION-GAPS.md
+++ b/docs/VALIDATION-GAPS.md
@@ -2,7 +2,7 @@
 
 > Gaps identified by comparing against YAFV (Node.js FHIR validator).
 > Date: 2026-03-06
-> Updated: 2026-07-31
+> Updated: 2026-07-31 (fhirpath v1.4.0)
 
 ## Resolved Gaps
 
@@ -297,12 +297,14 @@ What remains is ergonomics, neither of which changes a verdict:
 Open only if evidence appears:
   GO-GAP-005: Issue deduplication - no real duplicate found yet
 
-Blocked upstream in gofhir/fhirpath (9 constraints, see
+Blocked upstream in gofhir/fhirpath (8 constraints, see
 docs/plans/2026-07-30-fhirpath-engine-gaps.md):
-  ref-1                              type-name shadowing, silent false pass
   age-1 cnt-3 dis-1 drt-1 ras-1      %ucum undefined
   eld-19 eld-20                      published FHIR regex rejected as dangerous
   rng-2                              Quantity comparison unsupported
+
+Fixed upstream in fhirpath v1.4.0:
+  ref-1                              type-name shadowing - now evaluates and fails correctly
 ```
 
 Done: GO-GAP-001 (`compose.exclude`), GO-GAP-002 (filter operators) and version-aware

--- a/docs/plans/2026-07-30-fhirpath-engine-gaps.md
+++ b/docs/plans/2026-07-30-fhirpath-engine-gaps.md
@@ -1,9 +1,9 @@
-# Engine gaps blocking base R4 invariants — `gofhir/fhirpath` v1.1.0
+# Engine gaps blocking base R4 invariants — `gofhir/fhirpath`
 
 **For:** the `github.com/gofhir/fhirpath` maintainers
 **From:** the `github.com/gofhir/validator` maintainers
 **Date:** 2026-07-30
-**Engine:** `gofhir/fhirpath v1.1.0`
+**Engine:** `gofhir/fhirpath v1.4.0` (originally reported against v1.1.0)
 **Compared against:** HL7 `validator_cli` 6.9.12, FHIR R4 (4.0.1)
 
 None of these are worked around on our side. Affected constraints are reported as
@@ -13,6 +13,23 @@ gaps rather than changing cosmetics.
 They surfaced now because our constraint engine used to skip any element declaring more than
 one type, which made every constraint of every choice type unreachable — 167 elements in R4.
 With that fixed, these constraints are reached for the first time.
+
+## Status as of v1.4.0
+
+**Gap 1 is fixed.** Re-running the audit against v1.4.0: `0 of 3` shadowing candidates are
+shadowed, `Reference.reference` navigates to its value, and `ref-1` now fails where it should
+— verified end to end against the reference, which reports the same two errors at the same two
+paths. Zero false positives across 30 official examples carrying local references. The `trace()`
+output that used to reach stdout on every reference is gone as well.
+
+Gaps 2, 3 and 4 are unchanged in v1.4.0, still affecting 8 constraints.
+
+| # | Gap | Constraints | v1.4.0 |
+| --- | --- | --- | --- |
+| 1 | Type-name shadowing | `ref-1` | **fixed** |
+| 2 | `%ucum` undefined | `age-1` `cnt-3` `dis-1` `drt-1` `ras-1` | open |
+| 3 | Published FHIR regex rejected | `eld-19` `eld-20` | open |
+| 4 | `Quantity` comparison | `rng-2` | open |
 
 ## How this was measured
 
@@ -39,7 +56,9 @@ evaluation. `FPAUDIT_VERSION=4.3.0` or `5.0.0` re-runs it against R4B or R5.
 
 ---
 
-## 1. An element whose name matches its containing type returns the container
+## 1. An element whose name matches its containing type returns the container — FIXED in v1.4.0
+
+Kept for the record; the behaviour below is v1.1.0's.
 
 The engine infers a node's FHIR type from its shape, then treats an identifier matching that
 type name — **case-insensitively, in any position** — as a reference to the node itself
@@ -216,12 +235,11 @@ decidable in the common case without claiming unit conversion.
 
 ## Priority
 
-1. **Type-name shadowing** — a silent false pass on every `Reference`, and no diagnostic
-   admits it. The narrow fix is to resolve a type name to the node only when capitalised and
-   at the start of an expression.
-2. **`%ucum`** — five invariants, and the fix is a constant.
-3. **The regex guard** — two invariants, and it blocks patterns the specification publishes.
-4. **`Quantity` comparison** — one invariant; the correct fix needs unit handling.
+Type-name shadowing was the critical one and is fixed in v1.4.0. Of what remains:
+
+1. **`%ucum`** — five invariants, and the fix is a constant.
+2. **The regex guard** — two invariants, and it blocks patterns the specification publishes.
+3. **`Quantity` comparison** — one invariant; the correct fix needs unit handling.
 
 ## `gofhir/ucum` — audited, no defects found
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gofhir/validator
 go 1.25.0
 
 require (
-	github.com/gofhir/fhirpath v1.1.0
+	github.com/gofhir/fhirpath v1.4.0
 	github.com/gofhir/ucum v1.0.1
 	golang.org/x/net v0.33.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/gofhir/fhirpath v1.1.0 h1:x3eBXr4kqNKlXsKN0FAunrJ6/+4VkSuUijq9DBvrrr4=
 github.com/gofhir/fhirpath v1.1.0/go.mod h1:rVyKz5998KXcjtciieCxEs7Sn07HUTQbkYNCyW0c0yg=
+github.com/gofhir/fhirpath v1.4.0 h1:FKKPmNSlFKBwjSH1AfKSPp07Yw5EmL0enYltYmIBQaY=
+github.com/gofhir/fhirpath v1.4.0/go.mod h1:rVyKz5998KXcjtciieCxEs7Sn07HUTQbkYNCyW0c0yg=
 github.com/gofhir/ucum v1.0.1 h1:cUOj0akwQUmVAtLLYQpO/DuYxN+Or0EkEFPIgot+CvQ=
 github.com/gofhir/ucum v1.0.1/go.mod h1:si8TiDVqUvd22QZFJm4NhPlIA/TccGTFE3jrmgPxDEU=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/pkg/validator/reference_test.go
+++ b/pkg/validator/reference_test.go
@@ -100,15 +100,21 @@ func TestReferenceValidation(t *testing.T) {
 			expectWarnings: 0,
 		},
 		{
-			name:           "invalid-fragment-not-found",
-			file:           "../../testdata/m9-references/invalid-fragment-not-found.json",
-			expectErrors:   2, // Fragment reference not found + dom-3 (contained not referenced)
+			name: "invalid-fragment-not-found",
+			file: "../../testdata/m9-references/invalid-fragment-not-found.json",
+			// Fragment not found + dom-3 (contained not referenced) + ref-1. ref-1 became
+			// reachable with fhirpath v1.4.0, which fixed the type-name shadowing that made
+			// `reference` resolve to the container: startsWith('#') returned false, so the
+			// constraint could never fail. The reference reports both the resolution error and
+			// the constraint failure, as we now do.
+			expectErrors:   3,
 			expectWarnings: 2, // dom-6 for Observation and contained Patient
 		},
 		{
-			name:           "invalid-fragment-no-contained",
-			file:           "../../testdata/m9-references/invalid-fragment-no-contained.json",
-			expectErrors:   1, // Fragment reference but no contained array
+			name: "invalid-fragment-no-contained",
+			file: "../../testdata/m9-references/invalid-fragment-no-contained.json",
+			// Fragment reference with no contained array, plus ref-1 — see above.
+			expectErrors:   2,
 			expectWarnings: 1, // dom-6 for Observation
 		},
 	}


### PR DESCRIPTION
v1.4.0 fixes the type-name shadowing reported in #77. Re-running the dynamic audit confirms it:

```
before (v1.1.0):   1 of 3 shadowed    "reference" => {"reference":"#nope"}
after  (v1.4.0):   0 of 3 shadowed    "reference" => #nope
```

## The consequence: `ref-1` stops being a silent false pass

It could never fail before — `startsWith('#')` returned `false`, `.not()` returned `true`, and the disjunction short-circuited — on **every** `Reference` in **every** resource. It now reports where it should, matching the reference in both count and path:

```
HL7:   Error @ Patient.managingOrganization  Unable to resolve resource with reference '#nope'
       Error @ Patient.managingOrganization  Constraint failed: ref-1: ...

ours:  ERROR   ...managingOrganization.reference  Contained resource 'nope' not found
       ERROR   ...managingOrganization            Constraint failed: ref-1: ...
```

## Verified before trusting it

- **30 official examples** carrying local references: **zero** fail `ref-1`. That was the real risk of activating a constraint that had never run.
- Two reference fixtures needed expected error counts raised (2→3, 1→2). The new issue in each is `ref-1` — true positives the shadowing had been hiding.
- The `trace()` output that used to reach stdout on every local reference is **gone**, so the CLI no longer leaks engine diagnostics into its own output.

## Still open upstream

The other three gaps are unchanged in v1.4.0, blocking **8 constraints**:

| Gap | Constraints |
| --- | --- |
| `%ucum` undefined | `age-1` `cnt-3` `dis-1` `drt-1` `ras-1` |
| Published `ElementDefinition` regex rejected as dangerous | `eld-19` `eld-20` |
| `Quantity` comparison unsupported | `rng-2` |

Both documents now record which are fixed and which remain, so the report stays usable for the next round — and the audit re-runs with `FPAUDIT=1` against any engine version.

Full suite and `golangci-lint` clean.