### PR TITLE
feat(deps): fhirpath v1.5.1 and ucum v4, closing three of four engine gaps

### DIFF
--- a/docs/VALIDATION-GAPS.md
+++ b/docs/VALIDATION-GAPS.md
@@ -2,7 +2,7 @@
 
 > Gaps identified by comparing against YAFV (Node.js FHIR validator).
 > Date: 2026-03-06
-> Updated: 2026-07-31 (fhirpath v1.4.0)
+> Updated: 2026-07-31 (fhirpath v1.5.1, ucum/v4 v4.2.0)
 
 ## Resolved Gaps
 
@@ -297,14 +297,14 @@ What remains is ergonomics, neither of which changes a verdict:
 Open only if evidence appears:
   GO-GAP-005: Issue deduplication - no real duplicate found yet
 
-Blocked upstream in gofhir/fhirpath (8 constraints, see
+Blocked upstream in gofhir/fhirpath (2 constraints, see
 docs/plans/2026-07-30-fhirpath-engine-gaps.md):
-  age-1 cnt-3 dis-1 drt-1 ras-1      %ucum undefined
   eld-19 eld-20                      published FHIR regex rejected as dangerous
-  rng-2                              Quantity comparison unsupported
 
-Fixed upstream in fhirpath v1.4.0:
-  ref-1                              type-name shadowing - now evaluates and fails correctly
+Fixed upstream, now evaluating correctly:
+  ref-1                              type-name shadowing        (fhirpath v1.4.0)
+  age-1 cnt-3 dis-1 drt-1 ras-1      %ucum undefined            (fhirpath v1.5.1)
+  rng-2                              Quantity comparison        (fhirpath v1.5.1)
 ```
 
 Done: GO-GAP-001 (`compose.exclude`), GO-GAP-002 (filter operators) and version-aware

--- a/docs/plans/2026-07-30-fhirpath-engine-gaps.md
+++ b/docs/plans/2026-07-30-fhirpath-engine-gaps.md
@@ -3,7 +3,7 @@
 **For:** the `github.com/gofhir/fhirpath` maintainers
 **From:** the `github.com/gofhir/validator` maintainers
 **Date:** 2026-07-30
-**Engine:** `gofhir/fhirpath v1.4.0` (originally reported against v1.1.0)
+**Engine:** `gofhir/fhirpath v1.5.1` (originally reported against v1.1.0)
 **Compared against:** HL7 `validator_cli` 6.9.12, FHIR R4 (4.0.1)
 
 None of these are worked around on our side. Affected constraints are reported as
@@ -14,22 +14,41 @@ They surfaced now because our constraint engine used to skip any element declari
 one type, which made every constraint of every choice type unreachable — 167 elements in R4.
 With that fixed, these constraints are reached for the first time.
 
-## Status as of v1.4.0
+## Status as of v1.5.1 — three of four fixed
 
-**Gap 1 is fixed.** Re-running the audit against v1.4.0: `0 of 3` shadowing candidates are
-shadowed, `Reference.reference` navigates to its value, and `ref-1` now fails where it should
-— verified end to end against the reference, which reports the same two errors at the same two
-paths. Zero false positives across 30 official examples carrying local references. The `trace()`
-output that used to reach stdout on every reference is gone as well.
-
-Gaps 2, 3 and 4 are unchanged in v1.4.0, still affecting 8 constraints.
-
-| # | Gap | Constraints | v1.4.0 |
+| # | Gap | Constraints | Status |
 | --- | --- | --- | --- |
-| 1 | Type-name shadowing | `ref-1` | **fixed** |
-| 2 | `%ucum` undefined | `age-1` `cnt-3` `dis-1` `drt-1` `ras-1` | open |
-| 3 | Published FHIR regex rejected | `eld-19` `eld-20` | open |
-| 4 | `Quantity` comparison | `rng-2` | open |
+| 1 | Type-name shadowing | `ref-1` | **fixed in v1.4.0** |
+| 2 | `%ucum` undefined | `age-1` `cnt-3` `dis-1` `drt-1` `ras-1` | **fixed in v1.5.1** |
+| 3 | Published FHIR regex rejected as dangerous | `eld-19` `eld-20` | **open** |
+| 4 | `Quantity` comparison | `rng-2` | **fixed in v1.5.1** |
+
+Re-running the audit against v1.5.1 leaves **one** evaluation failure class, gap 3. Verified end
+to end that the two newly fixed ones now produce verdicts rather than could-not-evaluate
+warnings:
+
+```text
+age-1  Condition.onsetAge with a non-UCUM system
+       ERROR  Constraint failed: age-1: 'There SHALL be a code if there is a value ...'
+
+rng-2  MedicationRequest ... doseAndRate[0].doseRange, low 10 mg, high 2 mg
+       ERROR  Constraint failed: rng-2: 'If present, low SHALL have a lower value than high'
+```
+
+v1.5.1 also picked up `github.com/gofhir/ucum/v4` as a dependency, which is presumably how
+`%ucum` and quantity comparison were closed — the approach suggested at the end of gap 4.
+
+### A correction to how this was measured
+
+The first v1.5.1 run reported ten failure classes, including `TypeError: expected a String, got
+HumanName` across 30 constraints. Those were **artefacts of the audit, not engine defects**: it
+was cross-evaluating every expression against every synthetic instance, which used to be
+harmless because a mismatched navigation returned empty. Now that the engine is strict about
+types it raises a TypeError instead, so a Timing constraint evaluated against a Patient reports
+a type mismatch that says nothing about the engine.
+
+The audit now evaluates each expression only against an instance of its own type. The full
+validator suite passing unchanged on v1.5.1 is what showed those classes were not real.
 
 ## How this was measured
 
@@ -141,7 +160,9 @@ Each of those should have been a bare id.
 
 ---
 
-## 2. `%ucum` is undefined
+## 2. `%ucum` is undefined — FIXED in v1.5.1
+
+Kept for the record; the behaviour below is v1.1.0's.
 
 ```
 InvalidPathError: undefined variable: %ucum
@@ -208,7 +229,9 @@ loaded StructureDefinitions would keep the specification's own regexes working.
 
 ---
 
-## 4. Two `Quantity` values cannot be compared
+## 4. Two `Quantity` values cannot be compared — FIXED in v1.5.1
+
+Kept for the record; the behaviour below is v1.1.0's.
 
 ```
 InvalidOperationError: cannot apply 'compare' to Quantity and Quantity
@@ -233,13 +256,15 @@ decidable in the common case without claiming unit conversion.
 
 ---
 
-## Priority
+## What remains
 
-Type-name shadowing was the critical one and is fixed in v1.4.0. Of what remains:
+Only the regex guard, affecting `eld-19` and `eld-20`. It blocks a pattern the specification
+itself publishes, so `ElementDefinition.path` cannot be validated and a malformed path passes.
 
-1. **`%ucum`** — five invariants, and the fix is a constant.
-2. **The regex guard** — two invariants, and it blocks patterns the specification publishes.
-3. **`Quantity` comparison** — one invariant; the correct fix needs unit handling.
+Go's `regexp` is RE2, which has no catastrophic backtracking, so the consecutive-quantifier
+heuristic may be guarding a risk this engine does not carry. If the guard is needed for a
+non-RE2 path, an allowance for patterns coming from loaded StructureDefinitions would keep the
+specification's own regexes working.
 
 ## `gofhir/ucum` — audited, no defects found
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/gofhir/validator
 go 1.25.0
 
 require (
-	github.com/gofhir/fhirpath v1.4.0
-	github.com/gofhir/ucum v1.0.1
+	github.com/gofhir/fhirpath v1.5.1
+	github.com/gofhir/ucum/v4 v4.2.0
 	golang.org/x/net v0.33.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,12 +2,10 @@ github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYW
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
-github.com/gofhir/fhirpath v1.1.0 h1:x3eBXr4kqNKlXsKN0FAunrJ6/+4VkSuUijq9DBvrrr4=
-github.com/gofhir/fhirpath v1.1.0/go.mod h1:rVyKz5998KXcjtciieCxEs7Sn07HUTQbkYNCyW0c0yg=
-github.com/gofhir/fhirpath v1.4.0 h1:FKKPmNSlFKBwjSH1AfKSPp07Yw5EmL0enYltYmIBQaY=
-github.com/gofhir/fhirpath v1.4.0/go.mod h1:rVyKz5998KXcjtciieCxEs7Sn07HUTQbkYNCyW0c0yg=
-github.com/gofhir/ucum v1.0.1 h1:cUOj0akwQUmVAtLLYQpO/DuYxN+Or0EkEFPIgot+CvQ=
-github.com/gofhir/ucum v1.0.1/go.mod h1:si8TiDVqUvd22QZFJm4NhPlIA/TccGTFE3jrmgPxDEU=
+github.com/gofhir/fhirpath v1.5.1 h1:eOS6hE0oUQrdeJxhuhFIpCW9jWzeC4ZG9ZmuxHAEu8E=
+github.com/gofhir/fhirpath v1.5.1/go.mod h1:VcFSCvELo0i6VKP0OfR/kBT6IR9NdKJc70EzXeP9zNA=
+github.com/gofhir/ucum/v4 v4.2.0 h1:ougEnTQv42vXQmWkxS7qd7nIaSG7MHm4sHqhO3RFrIM=
+github.com/gofhir/ucum/v4 v4.2.0/go.mod h1:hk/uAUDzD7UFymbMrIglysUzUtfSeqLN5prsmf9yIbM=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=

--- a/pkg/constraint/enginegaps_test.go
+++ b/pkg/constraint/enginegaps_test.go
@@ -199,13 +199,14 @@ func TestAuditEngineExpressionGaps(t *testing.T) {
 			compileFails = append(compileFails, failure{e.key, e.sd, e.path, "-", e.expr, cerr.Error()})
 			continue
 		}
-		// Evaluate against the instance of its own type first, then every other shape.
-		order := make([]string, 0, 2+len(shapes))
-		order = append(order, e.sd, "empty")
-		for name := range shapes {
-			order = append(order, name)
-		}
-		for _, shapeName := range order {
+		// Only the instance of the constraint's own type, plus the empty object.
+		//
+		// Cross-evaluating every expression against every shape used to be harmless because
+		// a mismatched navigation just returned empty. Since the engine became strict about
+		// types it raises a TypeError instead, so a Timing constraint evaluated against a
+		// Patient reports "expected a String, got HumanName" — a fact about the audit, not
+		// about the engine. Reporting those upstream would waste the maintainers' time.
+		for _, shapeName := range []string{e.sd, "empty"} {
 			shape, ok := shapes[shapeName]
 			if !ok {
 				continue

--- a/pkg/ucumvalidator/ucumvalidator.go
+++ b/pkg/ucumvalidator/ucumvalidator.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gofhir/validator/pkg/registry"
 	"github.com/gofhir/validator/pkg/walker"
 
-	"github.com/gofhir/ucum"
+	"github.com/gofhir/ucum/v4"
 )
 
 const (

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gofhir/validator/pkg/terminology"
 	"github.com/gofhir/validator/pkg/ucumvalidator"
 
-	"github.com/gofhir/ucum"
+	"github.com/gofhir/ucum/v4"
 )
 
 func init() {


### PR DESCRIPTION
## Engine gaps: three of four now closed

| # | Gap | Constraints | Status |
| --- | --- | --- | --- |
| 1 | Type-name shadowing | `ref-1` | fixed in v1.4.0 |
| 2 | `%ucum` undefined | `age-1` `cnt-3` `dis-1` `drt-1` `ras-1` | **fixed in v1.5.1** |
| 3 | Published FHIR regex rejected as dangerous | `eld-19` `eld-20` | **open** |
| 4 | `Quantity` comparison | `rng-2` | **fixed in v1.5.1** |

v1.5.1 picked up `github.com/gofhir/ucum/v4` as a dependency — presumably how gaps 2 and 4 were closed, since both needed unit handling. That was the approach suggested at the end of gap 4 in the report.

Verified end to end that both now produce verdicts instead of could-not-evaluate warnings:

```
age-1   Condition.onsetAge with a non-UCUM system
        ERROR  Constraint failed: age-1: 'There SHALL be a code if there is a value ...'

rng-2   MedicationRequest ... doseAndRate[0].doseRange, low 10 mg, high 2 mg
        ERROR  Constraint failed: rng-2: 'If present, low SHALL have a lower value than high'
```

## `ucum` v1.0.1 → v4.2.0

We were **three majors behind**, and since fhirpath v1.5.1 depends on `ucum/v4` the build briefly carried **both**: `go.mod` listed v1.0.1 while the engine used v4.2.0. Now one version.

The API we consume is unchanged (`Service`, `New`, `Validate`), and v4's own docs confirm `New` remains correct:

> "Within this variant case carries no meaning... **FHIR uses the case-sensitive form, so New is the right choice there.**"

All 30 codes from the earlier audit return the same verdict — 20 valid, 10 invalid, no drift.

**Worth knowing for future updates:** tags v2 and above are only visible to Go under the `github.com/gofhir/ucum/v4` module path, so `go list -m -versions github.com/gofhir/ucum` stops at v1.0.1 and *looks* stale when it isn't. The repo has tags through v4.2.0.

## A correction to the audit itself

Its first v1.5.1 run reported **ten** failure classes, including `TypeError: expected a String, got HumanName` across 30 constraints. Those were **artefacts of the audit, not engine defects**.

It was cross-evaluating every expression against every synthetic instance — harmless while a mismatched navigation returned empty, but the engine is now strict about types and raises a TypeError instead. So a Timing constraint evaluated against a Patient reported a type mismatch that says nothing about the engine.

The audit now evaluates each expression only against an instance of its own type, which brings it to one real class. The full validator suite passing unchanged on v1.5.1 is what showed those classes were not real — worth noting, because reporting them upstream would have wasted the maintainers' time.

## `models`

Not a dependency of this project, so nothing to update. Its newer tags also resolve as `unknown revision` through the module proxy.

Full suite and `golangci-lint` clean.