### PR TITLE
docs: the remaining regex gap is a guard bug, not a policy call

### DIFF
--- a/docs/VALIDATION-GAPS.md
+++ b/docs/VALIDATION-GAPS.md
@@ -2,7 +2,7 @@
 
 > Gaps identified by comparing against YAFV (Node.js FHIR validator).
 > Date: 2026-03-06
-> Updated: 2026-07-31 (fhirpath v1.4.0)
+> Updated: 2026-07-31 (fhirpath v1.5.1, ucum/v4 v4.2.0)
 
 ## Resolved Gaps
 
@@ -297,14 +297,14 @@ What remains is ergonomics, neither of which changes a verdict:
 Open only if evidence appears:
   GO-GAP-005: Issue deduplication - no real duplicate found yet
 
-Blocked upstream in gofhir/fhirpath (8 constraints, see
+Blocked upstream in gofhir/fhirpath (2 constraints, see
 docs/plans/2026-07-30-fhirpath-engine-gaps.md):
-  age-1 cnt-3 dis-1 drt-1 ras-1      %ucum undefined
   eld-19 eld-20                      published FHIR regex rejected as dangerous
-  rng-2                              Quantity comparison unsupported
 
-Fixed upstream in fhirpath v1.4.0:
-  ref-1                              type-name shadowing - now evaluates and fails correctly
+Fixed upstream, now evaluating correctly:
+  ref-1                              type-name shadowing        (fhirpath v1.4.0)
+  age-1 cnt-3 dis-1 drt-1 ras-1      %ucum undefined            (fhirpath v1.5.1)
+  rng-2                              Quantity comparison        (fhirpath v1.5.1)
 ```
 
 Done: GO-GAP-001 (`compose.exclude`), GO-GAP-002 (filter operators) and version-aware

--- a/docs/plans/2026-07-30-fhirpath-engine-gaps.md
+++ b/docs/plans/2026-07-30-fhirpath-engine-gaps.md
@@ -20,7 +20,7 @@ With that fixed, these constraints are reached for the first time.
 | --- | --- | --- | --- |
 | 1 | Type-name shadowing | `ref-1` | **fixed in v1.4.0** |
 | 2 | `%ucum` undefined | `age-1` `cnt-3` `dis-1` `drt-1` `ras-1` | **fixed in v1.5.1** |
-| 3 | Published FHIR regex rejected as dangerous | `eld-19` `eld-20` | **open** |
+| 3 | ReDoS guard misidentifies quantifiers | `eld-19` `eld-20` | **open — bug, see below** |
 | 4 | `Quantity` comparison | `rng-2` | **fixed in v1.5.1** |
 
 Re-running the audit against v1.5.1 leaves **one** evaluation failure class, gap 3. Verified end
@@ -188,46 +188,80 @@ in HL7, and an unevaluatable-constraint warning for us.
 
 ---
 
-## 3. A published FHIR regex is rejected as dangerous
+## 3. The ReDoS guard misidentifies the pattern it is looking for
 
 ```
 InvalidExpressionError: potentially dangerous regex: consecutive quantifiers
 ```
 
-Affects `eld-19` and `eld-20` on `ElementDefinition`, whose patterns are published by HL7 in
-the R4 specification itself:
+This is not a policy that needs relaxing — the guard has an implementation bug and rejects
+valid patterns it was never meant to catch. Its own comment states the intent:
+
+```go
+case '*', '+', '?':
+    quantifierRun++
+    if prevWasQuant {
+        // Consecutive quantifiers like ** or *+ are dangerous
+        return eval.NewEvalError(eval.ErrInvalidExpression,
+            "potentially dangerous regex: consecutive quantifiers")
+    }
+    prevWasQuant = true
+```
+`funcs/regex.go:255`
+
+`prevWasQuant` is cleared only in the `default:` branch. `case '('` and `case ')'` fall through
+without clearing it, so a quantifier, a group close, and another quantifier read as adjacent:
 
 ```
-eld-19: path.matches('[^\s\.,:;\'"\/|?!@#$%&*()\[\]{}]{1,64}(\.[^\s\.,:;\'"\/|?!@#$%&*()\[\]{}]{1,64}(\[x\])?(\:[^\s\.]+)?)*')
+(a+)?     +  sets the flag  ->  )  leaves it set  ->  ?  sees it  ->  rejected
 ```
 
-The ReDoS guard is a good idea, but here it rejects a pattern that ships with the
-specification, so `ElementDefinition.path` cannot be validated at all — which matters for
-anyone validating StructureDefinitions, profiles or IG content.
+Two distinct false positives follow, both reproducible in six characters:
 
-Confirmed end to end on a StructureDefinition whose differential declares
-`"path": "Patient has spaces, and #bad chars!"`:
+| Pattern | Verdict | Should be |
+| --- | --- | --- |
+| `(a+)?` | rejected | valid — quantified group, then optional |
+| `(a*)?` | rejected | valid |
+| `(a+)*` | rejected | valid |
+| `a+?` | rejected | valid — `?` here is the lazy modifier, not a second quantifier |
+| `a**` | rejected | correct, and RE2 rejects it unaided |
+| `(a)(b)` | accepted | correct |
+| `a{1,3}(b)?` | accepted | correct — `}` hits `default:` and clears the flag |
 
-```text
-HL7:    Error   @ StructureDefinition.differential.element[1]
-                  Constraint failed: eld-19: 'Element names cannot include some special characters'
-        Warning @ StructureDefinition.differential.element[1]
-                  Constraint failed: eld-20: 'Element names should be simple alphanumerics ...'
+So `a+?`, standard non-greedy syntax, is unusable, and any quantified group followed by a
+quantifier is too. That is what `eld-19` trips over — its `...(\:[^\s\.]+)?)*` ends in exactly
+the `+)?` shape.
 
-ours:   Warning @ StructureDefinition.differential.element[1]
-                  Could not evaluate constraint 'eld-19': potentially dangerous regex
-        Warning @ StructureDefinition.differential.element[1]
-                  Could not evaluate constraint 'eld-20': potentially dangerous regex
-```
+### Why this belongs to the engine rather than to us or to HL7
 
-The `SHALL`-level `eld-19` never produces a verdict, so a malformed element path passes.
+- The rejection is decided in the engine's own code, at the line above. We only pass through the
+  expression the specification publishes, and HL7's validator evaluates the same pattern without
+  complaint.
+- The risk the guard cites does not exist here: the engine compiles with `regexp.Compile` and
+  matches with `re.MatchString` (`funcs/regex.go:79`, `:158`), which is **RE2** — linear time, no
+  backtracking, so catastrophic backtracking is not reachable.
+- RE2 already rejects genuinely malformed patterns on its own: `a**` fails to compile without any
+  help from the guard.
+- A second and effective defence is already in place — `MatchString` runs under a timeout
+  (`DefaultRegexCache` uses 100ms), which bounds any pathological input regardless of shape.
+- We cannot fix it downstream without reimplementing `ElementDefinition.path` validation by hand,
+  which would duplicate a rule the SD already publishes.
 
-Worth considering: Go's `regexp` is RE2, which has no catastrophic backtracking, so the
-consecutive-quantifier heuristic may be guarding against a risk the underlying engine does
-not carry. If the guard is needed for a non-RE2 path, an allowance for patterns coming from
-loaded StructureDefinitions would keep the specification's own regexes working.
+The narrow fix is to clear `prevWasQuant` when crossing `(` and `)`, and to treat `?` following
+another quantifier as the lazy modifier rather than a second quantifier.
 
----
+### What it costs while open
+
+`eld-19` (error) and `eld-20` (warning) are declared on `ElementDefinition`, which in all of R4
+appears in exactly two places: `StructureDefinition.differential.element` and
+`StructureDefinition.snapshot.element`. No clinical resource is affected — only profiles and IG
+content.
+
+The cost is concentrated there and scales with the profile: since the failure is a property of
+the expression rather than of the data, it repeats per element. A StructureDefinition with nine
+elements produces 21 issues of which **18 are this same message**; one with a full snapshot of
+200 elements produces roughly 400. They are warnings, and `-strict` does not promote them, so
+nothing fails — but they bury real findings.
 
 ## 4. Two `Quantity` values cannot be compared — FIXED in v1.5.1
 
@@ -258,13 +292,10 @@ decidable in the common case without claiming unit conversion.
 
 ## What remains
 
-Only the regex guard, affecting `eld-19` and `eld-20`. It blocks a pattern the specification
-itself publishes, so `ElementDefinition.path` cannot be validated and a malformed path passes.
-
-Go's `regexp` is RE2, which has no catastrophic backtracking, so the consecutive-quantifier
-heuristic may be guarding a risk this engine does not carry. If the guard is needed for a
-non-RE2 path, an allowance for patterns coming from loaded StructureDefinitions would keep the
-specification's own regexes working.
+Only gap 3, and it is a bug rather than a policy call: the guard's flag is not cleared when
+crossing `(` or `)`, so `(a+)?` and `a+?` are rejected as "consecutive quantifiers" though
+neither is. Six-character reproductions are in that section, which should make it quick to
+confirm and fix.
 
 ## `gofhir/ucum` — audited, no defects found
 

--- a/docs/plans/2026-07-30-fhirpath-engine-gaps.md
+++ b/docs/plans/2026-07-30-fhirpath-engine-gaps.md
@@ -3,7 +3,7 @@
 **For:** the `github.com/gofhir/fhirpath` maintainers
 **From:** the `github.com/gofhir/validator` maintainers
 **Date:** 2026-07-30
-**Engine:** `gofhir/fhirpath v1.4.0` (originally reported against v1.1.0)
+**Engine:** `gofhir/fhirpath v1.5.1` (originally reported against v1.1.0)
 **Compared against:** HL7 `validator_cli` 6.9.12, FHIR R4 (4.0.1)
 
 None of these are worked around on our side. Affected constraints are reported as
@@ -14,22 +14,41 @@ They surfaced now because our constraint engine used to skip any element declari
 one type, which made every constraint of every choice type unreachable — 167 elements in R4.
 With that fixed, these constraints are reached for the first time.
 
-## Status as of v1.4.0
+## Status as of v1.5.1 — three of four fixed
 
-**Gap 1 is fixed.** Re-running the audit against v1.4.0: `0 of 3` shadowing candidates are
-shadowed, `Reference.reference` navigates to its value, and `ref-1` now fails where it should
-— verified end to end against the reference, which reports the same two errors at the same two
-paths. Zero false positives across 30 official examples carrying local references. The `trace()`
-output that used to reach stdout on every reference is gone as well.
-
-Gaps 2, 3 and 4 are unchanged in v1.4.0, still affecting 8 constraints.
-
-| # | Gap | Constraints | v1.4.0 |
+| # | Gap | Constraints | Status |
 | --- | --- | --- | --- |
-| 1 | Type-name shadowing | `ref-1` | **fixed** |
-| 2 | `%ucum` undefined | `age-1` `cnt-3` `dis-1` `drt-1` `ras-1` | open |
-| 3 | Published FHIR regex rejected | `eld-19` `eld-20` | open |
-| 4 | `Quantity` comparison | `rng-2` | open |
+| 1 | Type-name shadowing | `ref-1` | **fixed in v1.4.0** |
+| 2 | `%ucum` undefined | `age-1` `cnt-3` `dis-1` `drt-1` `ras-1` | **fixed in v1.5.1** |
+| 3 | Published FHIR regex rejected as dangerous | `eld-19` `eld-20` | **open** |
+| 4 | `Quantity` comparison | `rng-2` | **fixed in v1.5.1** |
+
+Re-running the audit against v1.5.1 leaves **one** evaluation failure class, gap 3. Verified end
+to end that the two newly fixed ones now produce verdicts rather than could-not-evaluate
+warnings:
+
+```text
+age-1  Condition.onsetAge with a non-UCUM system
+       ERROR  Constraint failed: age-1: 'There SHALL be a code if there is a value ...'
+
+rng-2  MedicationRequest ... doseAndRate[0].doseRange, low 10 mg, high 2 mg
+       ERROR  Constraint failed: rng-2: 'If present, low SHALL have a lower value than high'
+```
+
+v1.5.1 also picked up `github.com/gofhir/ucum/v4` as a dependency, which is presumably how
+`%ucum` and quantity comparison were closed — the approach suggested at the end of gap 4.
+
+### A correction to how this was measured
+
+The first v1.5.1 run reported ten failure classes, including `TypeError: expected a String, got
+HumanName` across 30 constraints. Those were **artefacts of the audit, not engine defects**: it
+was cross-evaluating every expression against every synthetic instance, which used to be
+harmless because a mismatched navigation returned empty. Now that the engine is strict about
+types it raises a TypeError instead, so a Timing constraint evaluated against a Patient reports
+a type mismatch that says nothing about the engine.
+
+The audit now evaluates each expression only against an instance of its own type. The full
+validator suite passing unchanged on v1.5.1 is what showed those classes were not real.
 
 ## How this was measured
 
@@ -141,7 +160,9 @@ Each of those should have been a bare id.
 
 ---
 
-## 2. `%ucum` is undefined
+## 2. `%ucum` is undefined — FIXED in v1.5.1
+
+Kept for the record; the behaviour below is v1.1.0's.
 
 ```
 InvalidPathError: undefined variable: %ucum
@@ -208,7 +229,9 @@ loaded StructureDefinitions would keep the specification's own regexes working.
 
 ---
 
-## 4. Two `Quantity` values cannot be compared
+## 4. Two `Quantity` values cannot be compared — FIXED in v1.5.1
+
+Kept for the record; the behaviour below is v1.1.0's.
 
 ```
 InvalidOperationError: cannot apply 'compare' to Quantity and Quantity
@@ -233,13 +256,15 @@ decidable in the common case without claiming unit conversion.
 
 ---
 
-## Priority
+## What remains
 
-Type-name shadowing was the critical one and is fixed in v1.4.0. Of what remains:
+Only the regex guard, affecting `eld-19` and `eld-20`. It blocks a pattern the specification
+itself publishes, so `ElementDefinition.path` cannot be validated and a malformed path passes.
 
-1. **`%ucum`** — five invariants, and the fix is a constant.
-2. **The regex guard** — two invariants, and it blocks patterns the specification publishes.
-3. **`Quantity` comparison** — one invariant; the correct fix needs unit handling.
+Go's `regexp` is RE2, which has no catastrophic backtracking, so the consecutive-quantifier
+heuristic may be guarding a risk this engine does not carry. If the guard is needed for a
+non-RE2 path, an allowance for patterns coming from loaded StructureDefinitions would keep the
+specification's own regexes working.
 
 ## `gofhir/ucum` — audited, no defects found
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/gofhir/validator
 go 1.25.0
 
 require (
-	github.com/gofhir/fhirpath v1.4.0
-	github.com/gofhir/ucum v1.0.1
+	github.com/gofhir/fhirpath v1.5.1
+	github.com/gofhir/ucum/v4 v4.2.0
 	golang.org/x/net v0.33.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,12 +2,10 @@ github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYW
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
-github.com/gofhir/fhirpath v1.1.0 h1:x3eBXr4kqNKlXsKN0FAunrJ6/+4VkSuUijq9DBvrrr4=
-github.com/gofhir/fhirpath v1.1.0/go.mod h1:rVyKz5998KXcjtciieCxEs7Sn07HUTQbkYNCyW0c0yg=
-github.com/gofhir/fhirpath v1.4.0 h1:FKKPmNSlFKBwjSH1AfKSPp07Yw5EmL0enYltYmIBQaY=
-github.com/gofhir/fhirpath v1.4.0/go.mod h1:rVyKz5998KXcjtciieCxEs7Sn07HUTQbkYNCyW0c0yg=
-github.com/gofhir/ucum v1.0.1 h1:cUOj0akwQUmVAtLLYQpO/DuYxN+Or0EkEFPIgot+CvQ=
-github.com/gofhir/ucum v1.0.1/go.mod h1:si8TiDVqUvd22QZFJm4NhPlIA/TccGTFE3jrmgPxDEU=
+github.com/gofhir/fhirpath v1.5.1 h1:eOS6hE0oUQrdeJxhuhFIpCW9jWzeC4ZG9ZmuxHAEu8E=
+github.com/gofhir/fhirpath v1.5.1/go.mod h1:VcFSCvELo0i6VKP0OfR/kBT6IR9NdKJc70EzXeP9zNA=
+github.com/gofhir/ucum/v4 v4.2.0 h1:ougEnTQv42vXQmWkxS7qd7nIaSG7MHm4sHqhO3RFrIM=
+github.com/gofhir/ucum/v4 v4.2.0/go.mod h1:hk/uAUDzD7UFymbMrIglysUzUtfSeqLN5prsmf9yIbM=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=

--- a/pkg/constraint/enginegaps_test.go
+++ b/pkg/constraint/enginegaps_test.go
@@ -199,13 +199,14 @@ func TestAuditEngineExpressionGaps(t *testing.T) {
 			compileFails = append(compileFails, failure{e.key, e.sd, e.path, "-", e.expr, cerr.Error()})
 			continue
 		}
-		// Evaluate against the instance of its own type first, then every other shape.
-		order := make([]string, 0, 2+len(shapes))
-		order = append(order, e.sd, "empty")
-		for name := range shapes {
-			order = append(order, name)
-		}
-		for _, shapeName := range order {
+		// Only the instance of the constraint's own type, plus the empty object.
+		//
+		// Cross-evaluating every expression against every shape used to be harmless because
+		// a mismatched navigation just returned empty. Since the engine became strict about
+		// types it raises a TypeError instead, so a Timing constraint evaluated against a
+		// Patient reports "expected a String, got HumanName" — a fact about the audit, not
+		// about the engine. Reporting those upstream would waste the maintainers' time.
+		for _, shapeName := range []string{e.sd, "empty"} {
 			shape, ok := shapes[shapeName]
 			if !ok {
 				continue

--- a/pkg/ucumvalidator/ucumvalidator.go
+++ b/pkg/ucumvalidator/ucumvalidator.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gofhir/validator/pkg/registry"
 	"github.com/gofhir/validator/pkg/walker"
 
-	"github.com/gofhir/ucum"
+	"github.com/gofhir/ucum/v4"
 )
 
 const (

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gofhir/validator/pkg/terminology"
 	"github.com/gofhir/validator/pkg/ucumvalidator"
 
-	"github.com/gofhir/ucum"
+	"github.com/gofhir/ucum/v4"
 )
 
 func init() {


### PR DESCRIPTION
Answering **"why should fhirpath fix this?"** properly. The earlier write-up asserted RE2 without checking and framed the gap as an overly strict policy. Both were sloppy, and the real answer is sharper.

## The guard does not do what its own comment says

```go
case '*', '+', '?':
    quantifierRun++
    if prevWasQuant {
        // Consecutive quantifiers like ** or *+ are dangerous
        return eval.NewEvalError(...)
    }
    prevWasQuant = true
```
`funcs/regex.go:255`

`prevWasQuant` is cleared **only** in the `default:` branch. `case '('` and `case ')'` fall through without clearing it, so a quantifier, a group close, and another quantifier read as adjacent:

```
(a+)?    + sets the flag  ->  ) leaves it set  ->  ? sees it  ->  rejected
```

Two separate false positives, reproducible in six characters:

| Pattern | Verdict | Should be |
| --- | --- | --- |
| `(a+)?` `(a*)?` `(a+)*` | rejected | valid — quantified group then quantifier |
| `a+?` | rejected | valid — that `?` is the **lazy modifier**, not a second quantifier |
| `a**` | rejected | correct, and RE2 rejects it unaided |
| `(a)(b)`, `a{1,3}(b)?` | accepted | correct — `}` hits `default:` and clears the flag |

So standard non-greedy syntax is unusable. `eld-19` trips over it because its `(\:[^\s\.]+)?)*` tail is exactly the `+)?` shape.

## Why it belongs to the engine

- The rejection is decided in the engine's own code, at the line above. We only pass through the expression the specification publishes, and HL7's validator evaluates the same pattern without complaint.
- **The cited risk does not exist here** — verified, not assumed: it compiles with `regexp.Compile` and matches with `re.MatchString` (`funcs/regex.go:79`, `:158`), which is RE2. Linear time, no backtracking.
- RE2 already rejects genuinely malformed patterns unaided: `a**` fails to compile without the guard's help.
- A second, effective defence is already there: `MatchString` runs under a timeout (100ms in `DefaultRegexCache`), bounding any pathological input regardless of shape.
- We cannot fix it downstream without reimplementing `ElementDefinition.path` validation by hand — duplicating a rule the SD already publishes.

**The narrow fix**: clear `prevWasQuant` when crossing `(` and `)`, and treat `?` after a quantifier as the lazy modifier.

## Scope and cost, measured

`eld-19` (error) and `eld-20` (warning) are declared on `ElementDefinition`, which in all of R4 appears in exactly two places: `StructureDefinition.differential.element` and `.snapshot.element`. **No clinical resource is affected** — only profiles and IG content.

But the failure belongs to the expression, not the data, so it repeats per element:

```
SD with   9 elements  ->  21 issues, 18 of them this one message
SD with 200 elements  ->  ~400 identical warnings
```

Warnings only, and `-strict` does not promote them, so nothing fails — they just bury real findings.

Docs only.