### PR TITLE
feat(deps): fhirpath v1.6.0 — substring panic fixed, R5 auditable for the first time

### DIFF
--- a/docs/plans/2026-07-30-fhirpath-engine-gaps.md
+++ b/docs/plans/2026-07-30-fhirpath-engine-gaps.md
@@ -3,7 +3,7 @@
 **For:** the `github.com/gofhir/fhirpath` maintainers
 **From:** the `github.com/gofhir/validator` maintainers
 **Date:** 2026-07-30
-**Engine:** `gofhir/fhirpath v1.5.1` (originally reported against v1.1.0)
+**Engine:** `gofhir/fhirpath v1.5.2` (originally reported against v1.1.0)
 **Compared against:** HL7 `validator_cli` 6.9.12, FHIR R4 (4.0.1)
 
 None of these are worked around on our side. Affected constraints are reported as
@@ -14,43 +14,73 @@ They surfaced now because our constraint engine used to skip any element declari
 one type, which made every constraint of every choice type unreachable — 167 elements in R4.
 With that fixed, these constraints are reached for the first time.
 
-## Status as of v1.5.1 — three of four fixed
+## Status as of v1.5.2 — all four original gaps closed, one new finding
 
 | # | Gap | Constraints | Status |
 | --- | --- | --- | --- |
-| 1 | Type-name shadowing | `ref-1` | **fixed in v1.4.0** |
-| 2 | `%ucum` undefined | `age-1` `cnt-3` `dis-1` `drt-1` `ras-1` | **fixed in v1.5.1** |
-| 3 | Published FHIR regex rejected as dangerous | `eld-19` `eld-20` | **open** |
-| 4 | `Quantity` comparison | `rng-2` | **fixed in v1.5.1** |
+| 1 | Type-name shadowing | `ref-1` | fixed in v1.4.0 |
+| 2 | `%ucum` undefined | `age-1` `cnt-3` `dis-1` `drt-1` `ras-1` | fixed in v1.5.1 |
+| 3 | ReDoS guard misidentifies quantifiers | `eld-19` `eld-20` | **fixed in v1.5.2** |
+| 4 | `Quantity` comparison | `rng-2` | fixed in v1.5.1 |
 
-Re-running the audit against v1.5.1 leaves **one** evaluation failure class, gap 3. Verified end
-to end that the two newly fixed ones now produce verdicts rather than could-not-evaluate
-warnings:
+v1.5.2 fixed the guard precisely: the five false positives now pass and the genuinely
+consecutive ones stay rejected.
 
 ```text
-age-1  Condition.onsetAge with a non-UCUM system
-       ERROR  Constraint failed: age-1: 'There SHALL be a code if there is a value ...'
-
-rng-2  MedicationRequest ... doseAndRate[0].doseRange, low 10 mg, high 2 mg
-       ERROR  Constraint failed: rng-2: 'If present, low SHALL have a lower value than high'
+(a+)?  (a*)?  (a+)*  a+?  a*?     accepted   (were rejected)
+a**    a*+                        rejected   (correct — RE2 rejects them unaided)
 ```
 
-v1.5.1 also picked up `github.com/gofhir/ucum/v4` as a dependency, which is presumably how
-`%ucum` and quantity comparison were closed — the approach suggested at the end of gap 4.
+The audit is now clean across three FHIR versions:
 
-### A correction to how this was measured
+| Version | Constraints | Compile failures | Evaluation failures |
+| --- | --- | --- | --- |
+| R4 4.0.1 | 252 | 0 | 0 |
+| R4B 4.3.0 | 256 | 0 | 0 |
+| R5 5.0.0 | 330 | 1 — see below | 0 |
 
-The first v1.5.1 run reported ten failure classes, including `TypeError: expected a String, got
-HumanName` across 30 constraints. Those were **artefacts of the audit, not engine defects**: it
-was cross-evaluating every expression against every synthetic instance, which used to be
-harmless because a mismatched navigation returned empty. Now that the engine is strict about
-types it raises a TypeError instead, so a Timing constraint evaluated against a Patient reports
-a type mismatch that says nothing about the engine.
+The noise this used to generate is gone too: a StructureDefinition that produced 21 issues, 18
+of them the same unevaluatable-constraint warning, now produces 3.
 
-The audit now evaluates each expression only against an instance of its own type. The full
-validator suite passing unchanged on v1.5.1 is what showed those classes were not real.
+## New finding: `matches()` searches instead of testing the whole string
 
-## How this was measured
+Not caught by the audit, which only asks whether an expression evaluates without error. Found by
+checking `eld-19` end to end after v1.5.2 made it evaluable: it evaluates, and returns the wrong
+answer.
+
+```text
+'abc def'.matches('abc')      => true    expected false
+'xabcx'.matches('abc')        => true    expected false
+'abc'.matches('abc')          => true    correct
+```
+
+A partial match makes every validation regex vacuous: any string containing an acceptable
+substring passes. `eld-19` is the case in hand — a `path` of `"Patient has spaces, and #bad
+chars!"` passes, because `Patient` matches the leading character class, where the reference
+reports an error.
+
+Anchored patterns are unaffected, which is why R5's `cnl-1` (`matches('^[^|# ]+$')`) behaves
+correctly — verified returning `false` for a URL containing a pipe.
+
+The specification is not explicit here. It says only *"Returns `true` when the value matches the
+given regular expression"*, without stating whether the whole input is tested. The case for
+anchoring is that the reference implementation behaves that way — HL7's validator reports
+`eld-19` on the path above — and that the alternative empties every regex constraint of meaning.
+Roughly 37 constraints in the R4 corpus use `matches()`.
+
+## R5 `eld-11` does not compile — and that one is HL7's
+
+```text
+lexer errors: token recognition error at: '"' ':' '"'
+eld-11: ... or type.code.contains(":") or ...
+```
+
+The literal is double-quoted. FHIRPath states *"String literals are surrounded by
+single-quotes"*, so `":"` is not a string literal and the engine is right to reject it. This is a
+defect in the published R5 StructureDefinition rather than in the engine, and belongs upstream
+with HL7. Worth knowing that HL7's own validator tolerates it.
+
+## How this was measured## How this was measured
 
 `pkg/constraint/enginegaps_test.go` (run with `FPAUDIT=1`) derives everything from the
 StructureDefinitions in the loaded packages — nothing is enumerated by hand, so it stays
@@ -61,8 +91,17 @@ correct across FHIR versions and package sets:
 - shadowing candidates are found by comparing each element's name against the type
   containing it
 
-Result: **252 distinct published constraints, 0 compile failures.** Every gap below is in
-evaluation. `FPAUDIT_VERSION=4.3.0` or `5.0.0` re-runs it against R4B or R5.
+`FPAUDIT_VERSION=4.3.0` or `5.0.0` re-runs it against R4B or R5.
+
+Two limits worth stating, both learned by getting them wrong:
+
+- Each expression is evaluated **only** against an instance of its own type, and with the node it
+  is declared on as context. Cross-evaluating shapes reported type mismatches that were facts
+  about the audit, not the engine — a Timing constraint against a Patient, `matches()` against
+  the empty object.
+- Where the declared context cannot be built, the constraint is **skipped and counted** rather
+  than evaluated against the wrong node: 30 of 252 in R4, 58 of 330 in R5, all of them declared
+  on backbone elements the synthetic instances do not model. Those are unaudited, not clean.
 
 ## Summary
 

--- a/docs/plans/2026-07-30-fhirpath-engine-gaps.md
+++ b/docs/plans/2026-07-30-fhirpath-engine-gaps.md
@@ -33,14 +33,51 @@ a**    a*+                        rejected   (correct — RE2 rejects them unaid
 
 The audit is now clean across three FHIR versions:
 
-| Version | Constraints | Compile failures | Evaluation failures |
-| --- | --- | --- | --- |
-| R4 4.0.1 | 252 | 0 | 0 |
-| R4B 4.3.0 | 256 | 0 | 0 |
-| R5 5.0.0 | 330 | 1 — see below | 0 |
+| Version | Constraints | Skipped (no context) | Compile failures | Evaluation failures |
+| --- | --- | --- | --- | --- |
+| R4 4.0.1 | 252 | 5 | 0 | 0 |
+| R4B 4.3.0 | 256 | 6 | 0 | 2 — `sdf-24` `sdf-25`, unverified |
+| R5 5.0.0 | 330 | — | 1 — not the engine's | crashes, see below |
 
 The noise this used to generate is gone too: a StructureDefinition that produced 21 issues, 18
 of them the same unevaluatable-constraint warning, now produces 3.
+
+## New finding: `substring()` panics on a negative length
+
+The most serious of the new findings, because a panic is not an error a caller can handle — it
+unwinds the process. There is no `recover` on the evaluation path, in the engine or in this
+validator.
+
+```go
+'abc'.substring(0, -1)                  panic: slice bounds out of range [:-1]
+'abc'.substring(0, 'abc'.length()-10)   panic: slice bounds out of range [:-7]
+```
+
+`funcs/strings.go:385`. The neighbouring out-of-range cases are handled correctly, which is what
+makes this look like an oversight rather than a design choice:
+
+```text
+'abc'.substring(-1, 2)    => {}    correct
+'abc'.substring(10, 2)    => {}    correct
+'abc'.substring(0, 2)     => ab    correct
+```
+
+FHIRPath specifies empty for out-of-range arguments — *"If start lies outside the length of the
+string, the function returns empty"* — so a negative length should return `{}` as its siblings do.
+
+**Where it is reachable.** R5's `sdf-24` and `sdf-25` compute a length arithmetically:
+
+```
+id.substring(0, $this.length()-10)
+```
+
+Any `id` shorter than ten characters makes the argument negative, so validating a
+StructureDefinition crashes the process. Our audit hit it on the first R5 run.
+
+R4 and R4B are **not** exposed: their only `substring` use is `ref-1`'s single-argument
+`reference.substring(1)`, and that form is safe at every boundary we tried — `'#'.substring(1)`
+and `''.substring(1)` both return `{}`. Confirmed end to end that a Patient with
+`"reference": "#"` validates normally rather than crashing.
 
 ## New finding: `matches()` searches instead of testing the whole string
 
@@ -100,8 +137,10 @@ Two limits worth stating, both learned by getting them wrong:
   about the audit, not the engine — a Timing constraint against a Patient, `matches()` against
   the empty object.
 - Where the declared context cannot be built, the constraint is **skipped and counted** rather
-  than evaluated against the wrong node: 30 of 252 in R4, 58 of 330 in R5, all of them declared
-  on backbone elements the synthetic instances do not model. Those are unaudited, not clean.
+  than evaluated against the wrong node. Instances are now built by walking the full snapshot by
+  path rather than only direct children, which models backbone elements — `Measure.group.linkId`
+  is defined in Measure's snapshot, not in any separate SD. That took skipping from 30 of 252 to
+  **5** in R4 and from 58 of 330 to **6** in R4B. The remainder are unaudited, not clean.
 
 ## Summary
 

--- a/docs/plans/2026-07-30-fhirpath-engine-gaps.md
+++ b/docs/plans/2026-07-30-fhirpath-engine-gaps.md
@@ -3,7 +3,7 @@
 **For:** the `github.com/gofhir/fhirpath` maintainers
 **From:** the `github.com/gofhir/validator` maintainers
 **Date:** 2026-07-30
-**Engine:** `gofhir/fhirpath v1.5.2` (originally reported against v1.1.0)
+**Engine:** `gofhir/fhirpath v1.6.0` (originally reported against v1.1.0)
 **Compared against:** HL7 `validator_cli` 6.9.12, FHIR R4 (4.0.1)
 
 None of these are worked around on our side. Affected constraints are reported as
@@ -14,35 +14,65 @@ They surfaced now because our constraint engine used to skip any element declari
 one type, which made every constraint of every choice type unreachable — 167 elements in R4.
 With that fixed, these constraints are reached for the first time.
 
-## Status as of v1.5.2 — all four original gaps closed, one new finding
+## Status as of v1.6.0
 
-| # | Gap | Constraints | Status |
+Six findings so far, five closed.
+
+| # | Finding | Constraints | Status |
 | --- | --- | --- | --- |
 | 1 | Type-name shadowing | `ref-1` | fixed in v1.4.0 |
 | 2 | `%ucum` undefined | `age-1` `cnt-3` `dis-1` `drt-1` `ras-1` | fixed in v1.5.1 |
-| 3 | ReDoS guard misidentifies quantifiers | `eld-19` `eld-20` | **fixed in v1.5.2** |
+| 3 | ReDoS guard misidentifies quantifiers | `eld-19` `eld-20` | fixed in v1.5.2 |
 | 4 | `Quantity` comparison | `rng-2` | fixed in v1.5.1 |
+| 5 | `substring()` panics on negative length | R5 `sdf-24` `sdf-25` | **fixed in v1.6.0** (see note) |
+| 6 | `matches()` searches instead of testing the whole string | 32 of 37 R4 patterns | **open** |
 
-v1.5.2 fixed the guard precisely: the five false positives now pass and the genuinely
-consecutive ones stay rejected.
-
-```text
-(a+)?  (a*)?  (a+)*  a+?  a*?     accepted   (were rejected)
-a**    a*+                        rejected   (correct — RE2 rejects them unaided)
-```
-
-The audit is now clean across three FHIR versions:
+With the panic gone, R5 can be audited to completion for the first time — the crash used to cut
+the sweep short, so its earlier "results" were not results at all.
 
 | Version | Constraints | Skipped (no context) | Compile failures | Evaluation failures |
 | --- | --- | --- | --- | --- |
 | R4 4.0.1 | 252 | 5 | 0 | 0 |
-| R4B 4.3.0 | 256 | 6 | 0 | 2 — `sdf-24` `sdf-25`, unverified |
-| R5 5.0.0 | 330 | — | 1 — not the engine's | crashes, see below |
+| R4B 4.3.0 | 256 | 8 | 0 | 2 — HL7's, see below |
+| R5 5.0.0 | 330 | 6 | 1 — HL7's, see below | 0 |
 
-The noise this used to generate is gone too: a StructureDefinition that produced 21 issues, 18
-of them the same unevaluatable-constraint warning, now produces 3.
+Every remaining failure across the three versions belongs to the published specification rather
+than to the engine.
 
-## New finding: `substring()` panics on a negative length
+### Note on the v1.6.0 substring fix
+
+The panic is gone, but the return value is inconsistent with the sibling cases: a negative
+length yields a collection holding the empty string, where an out-of-range start yields an empty
+collection.
+
+```text
+'abc'.substring(0, -1)           => ""      a one-item collection
+'abc'.substring(-1, 2)           => {}      empty
+'abc'.substring(10, 2)           => {}      empty
+'abc'.substring(0, -1).exists()  => true    would be false with {}
+'abc'.substring(10, 2).exists()  => false
+```
+
+Practical impact today is nil — the only constraints reaching a negative length are R4B's
+`sdf-24`/`sdf-25`, which are themselves defective — but it is worth mentioning upstream for
+consistency, since constraints branch on `exists()`.
+
+### Two remaining failures that are HL7's, not the engine's
+
+**R4B `sdf-24` and `sdf-25`** compute `id.substring(0, $this.length()-10)`. Inside that `where`,
+`$this` is the element — an object — so `.length()` is a type error and the engine is right to
+say so. HL7 corrected it in R5, which is what settles the attribution:
+
+```text
+R4B:  id.substring(0, $this.length()-10)
+R5:   path.substring(0, $this.path.length()-…)     navigates to path first
+```
+
+**R5 `eld-11`** uses a double-quoted literal, `type.code.contains(":")`. FHIRPath states *"String
+literals are surrounded by single-quotes"*, so the engine is right to reject it. HL7's own
+validator tolerates it.
+
+## New finding: `substring()` panics## Finding 5: `substring()` panics on a negative length — fixed in v1.6.0
 
 The most serious of the new findings, because a panic is not an error a caller can handle — it
 unwinds the process. There is no `recover` on the evaluation path, in the engine or in this
@@ -79,7 +109,7 @@ R4 and R4B are **not** exposed: their only `substring` use is `ref-1`'s single-a
 and `''.substring(1)` both return `{}`. Confirmed end to end that a Patient with
 `"reference": "#"` validates normally rather than crashing.
 
-## New finding: `matches()` searches instead of testing the whole string
+## Finding 6: `matches()` searches instead of testing the whole string — OPEN
 
 Not caught by the audit, which only asks whether an expression evaluates without error. Found by
 checking `eld-19` end to end after v1.5.2 made it evaluable: it evaluates, and returns the wrong

--- a/docs/plans/2026-08-02-message-to-fhirpath-team.md
+++ b/docs/plans/2026-08-02-message-to-fhirpath-team.md
@@ -1,0 +1,115 @@
+# Message to the gofhir/fhirpath team
+
+Ready to send as a GitHub issue. Evidence and reproductions are all verified against v1.5.1.
+
+---
+
+**Title:** ReDoS guard rejects valid patterns: `prevWasQuant` not cleared across `(` and `)`
+
+---
+
+Thanks for v1.4.0 and v1.5.1 — three of the four gaps we reported are closed, and we have
+confirmed each one end to end against HL7 `validator_cli` 6.9.12:
+
+| Fixed in | What | Effect for us |
+| --- | --- | --- |
+| v1.4.0 | type-name shadowing | `ref-1` stopped being a silent false pass — it could never fail before, on every `Reference` in every resource |
+| v1.5.1 | `%ucum` undefined | `age-1`, `cnt-3`, `dis-1`, `drt-1`, `ras-1` now produce verdicts |
+| v1.5.1 | `Quantity` comparison | `rng-2` now produces a verdict |
+
+We also noticed the `trace()` output no longer reaches stdout, which had been leaking engine
+diagnostics into our CLI's own output. And we have migrated to `ucum/v4` after seeing v1.5.1
+pick it up.
+
+One gap remains, and on closer reading it looks like a bug rather than a policy decision.
+
+## The guard rejects patterns it was not meant to catch
+
+```go
+case '*', '+', '?':
+    quantifierRun++
+    if prevWasQuant {
+        // Consecutive quantifiers like ** or *+ are dangerous
+        return eval.NewEvalError(eval.ErrInvalidExpression,
+            "potentially dangerous regex: consecutive quantifiers")
+    }
+    prevWasQuant = true
+```
+
+`funcs/regex.go:255`
+
+`prevWasQuant` is cleared only in the `default:` branch. `case '('` and `case ')'` fall through
+without clearing it, so a quantifier, a group close, and another quantifier are read as
+adjacent:
+
+```
+(a+)?     +  sets the flag  →  )  leaves it set  →  ?  sees it  →  rejected
+```
+
+## Reproduction
+
+```go
+for _, expr := range []string{
+    `'aaa'.matches('(a+)?')`,
+    `'aaa'.matches('(a*)?')`,
+    `'aaa'.matches('(a+)*')`,
+    `'aaa'.matches('a+?')`,
+    `'aaa'.matches('a**')`,
+    `'aaa'.matches('a{1,3}(b)?')`,
+} {
+    e, _ := fhirpath.Compile(expr)
+    _, err := e.EvaluateWithContext(eval.NewContext([]byte(`{}`)))
+    fmt.Printf("%-32s %v\n", expr, err)
+}
+```
+
+Observed on v1.5.1:
+
+| Pattern | Result | Expected |
+| --- | --- | --- |
+| `(a+)?` | rejected | valid — quantified group, then optional |
+| `(a*)?` | rejected | valid |
+| `(a+)*` | rejected | valid |
+| `a+?` | rejected | valid — this `?` is the lazy modifier, not a second quantifier |
+| `a**` | rejected | correct, and RE2 rejects it unaided |
+| `a{1,3}(b)?` | accepted | correct — `}` reaches `default:` and clears the flag |
+
+Two distinct false positives fall out: any quantified group followed by a quantifier, and
+standard non-greedy syntax (`a+?`, `a*?`).
+
+## What it blocks
+
+`eld-19` and `eld-20` on `ElementDefinition`, whose patterns HL7 publishes in the R4
+specification. `eld-19` is `SHALL`-level:
+
+```
+eld-19: path.matches('[^\s\.,:;\'"\/|?!@#$%&*()\[\]{}]{1,64}(\.[^\s\.,:;\'"\/|?!@#$%&*()\[\]{}]{1,64}(\[x\])?(\:[^\s\.]+)?)*')
+```
+
+Its `(\:[^\s\.]+)?)*` tail is exactly the `+)?` shape above, so `ElementDefinition.path` cannot
+be validated at all and a malformed path passes. HL7's validator evaluates the same pattern
+without complaint, reporting `eld-19` as an error and `eld-20` as a warning on a path containing
+spaces and special characters.
+
+Scope is narrow but concentrated: `ElementDefinition` appears in only two places in all of R4 —
+`StructureDefinition.differential.element` and `.snapshot.element` — so no clinical resource is
+affected, only profiles and IG content. Because the failure is a property of the expression
+rather than of the data, it repeats per element: a nine-element StructureDefinition yields 21
+issues of which 18 are this one message, and a full 200-element snapshot yields roughly 400.
+
+## On the ReDoS concern
+
+Worth noting in case it affects how you want to fix it: the engine compiles with
+`regexp.Compile` and matches with `re.MatchString` (`funcs/regex.go:79`, `:158`), which is RE2 —
+linear time, no backtracking — so catastrophic backtracking is not reachable here. RE2 also
+rejects genuinely malformed patterns on its own; `a**` fails to compile without the guard's
+help. And `MatchString` already runs under a timeout (100ms in `DefaultRegexCache`), which
+bounds any pathological input regardless of shape.
+
+## Suggested fix
+
+Clear `prevWasQuant` when crossing `(` and `)`, and treat `?` immediately following another
+quantifier as the lazy modifier rather than a second quantifier. That keeps `a**` and `a*+`
+caught while letting `(a+)?` and `a+?` through.
+
+Happy to send a PR if that helps.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gofhir/validator
 go 1.25.0
 
 require (
-	github.com/gofhir/fhirpath v1.5.2
+	github.com/gofhir/fhirpath v1.6.0
 	github.com/gofhir/ucum/v4 v4.2.0
 	golang.org/x/net v0.33.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gofhir/validator
 go 1.25.0
 
 require (
-	github.com/gofhir/fhirpath v1.5.1
+	github.com/gofhir/fhirpath v1.5.2
 	github.com/gofhir/ucum/v4 v4.2.0
 	golang.org/x/net v0.33.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/gofhir/fhirpath v1.5.1 h1:eOS6hE0oUQrdeJxhuhFIpCW9jWzeC4ZG9ZmuxHAEu8E
 github.com/gofhir/fhirpath v1.5.1/go.mod h1:VcFSCvELo0i6VKP0OfR/kBT6IR9NdKJc70EzXeP9zNA=
 github.com/gofhir/fhirpath v1.5.2 h1:gXlCDExi+jOje7ivShCNmC1zrVhIj3InpsRSzduDaqs=
 github.com/gofhir/fhirpath v1.5.2/go.mod h1:VcFSCvELo0i6VKP0OfR/kBT6IR9NdKJc70EzXeP9zNA=
+github.com/gofhir/fhirpath v1.6.0 h1:b0p3mmk0qDd7uMF/20RH/ITNkA/POtXm1aGA/i17tT0=
+github.com/gofhir/fhirpath v1.6.0/go.mod h1:VcFSCvELo0i6VKP0OfR/kBT6IR9NdKJc70EzXeP9zNA=
 github.com/gofhir/ucum/v4 v4.2.0 h1:ougEnTQv42vXQmWkxS7qd7nIaSG7MHm4sHqhO3RFrIM=
 github.com/gofhir/ucum/v4 v4.2.0/go.mod h1:hk/uAUDzD7UFymbMrIglysUzUtfSeqLN5prsmf9yIbM=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/gofhir/fhirpath v1.5.1 h1:eOS6hE0oUQrdeJxhuhFIpCW9jWzeC4ZG9ZmuxHAEu8E=
 github.com/gofhir/fhirpath v1.5.1/go.mod h1:VcFSCvELo0i6VKP0OfR/kBT6IR9NdKJc70EzXeP9zNA=
+github.com/gofhir/fhirpath v1.5.2 h1:gXlCDExi+jOje7ivShCNmC1zrVhIj3InpsRSzduDaqs=
+github.com/gofhir/fhirpath v1.5.2/go.mod h1:VcFSCvELo0i6VKP0OfR/kBT6IR9NdKJc70EzXeP9zNA=
 github.com/gofhir/ucum/v4 v4.2.0 h1:ougEnTQv42vXQmWkxS7qd7nIaSG7MHm4sHqhO3RFrIM=
 github.com/gofhir/ucum/v4 v4.2.0/go.mod h1:hk/uAUDzD7UFymbMrIglysUzUtfSeqLN5prsmf9yIbM=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/pkg/constraint/enginegaps_test.go
+++ b/pkg/constraint/enginegaps_test.go
@@ -2,7 +2,6 @@ package constraint_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"sort"
 	"strings"
@@ -84,9 +83,11 @@ func collectConstraints(reg *registry.Registry) []constraintEntry {
 	return out
 }
 
-// syntheticInstance builds a JSON object for a type using its own ElementDefinitions:
-// each direct child is populated with a value of the type the SD declares. The depth
-// argument bounds recursion into complex children.
+// syntheticInstance builds a JSON object for a type from its own snapshot.
+//
+// It walks every element path, not just direct children, so backbone elements are modeled
+// too: Measure.group.linkId is defined in Measure's snapshot rather than in any separate SD,
+// and building only direct children left it with nowhere to point.
 func syntheticInstance(reg *registry.Registry, sd *registry.StructureDefinition, depth int) string {
 	if sd == nil || sd.Snapshot == nil || depth < 0 {
 		return "{}"
@@ -96,36 +97,81 @@ func syntheticInstance(reg *registry.Registry, sd *registry.StructureDefinition,
 		typeName = sd.ID
 	}
 
-	var fields []string
+	root := map[string]any{}
 	for i := range sd.Snapshot.Element {
 		elem := &sd.Snapshot.Element[i]
-		// direct children only
 		rest := strings.TrimPrefix(elem.Path, typeName+".")
-		if rest == elem.Path || strings.Contains(rest, ".") {
+		if rest == elem.Path || rest == "" || len(elem.Type) == 0 || elem.Max == "0" {
 			continue
 		}
-		if len(elem.Type) == 0 || elem.Max == "0" {
+		segs := strings.Split(rest, ".")
+		// Bound the tree: contentReference elements (Questionnaire.item.item) recur, and deep
+		// paths add nothing the constraints need.
+		if len(segs) > 4 {
 			continue
 		}
-		if rest == "id" || rest == "extension" || rest == "modifierExtension" {
-			continue
-		}
-		typeCode := elem.Type[0].Code
-		name := rest
-		if strings.HasSuffix(rest, "[x]") {
-			name = strings.TrimSuffix(rest, "[x]") + strings.ToUpper(typeCode[:1]) + typeCode[1:]
-		}
-		val := syntheticValue(reg, typeCode, depth)
-		if val == "" {
-			continue
-		}
-		if elem.Max == "*" {
-			val = "[" + val + "]"
-		}
-		fields = append(fields, fmt.Sprintf("%q:%s", name, val))
+		insertPath(reg, root, segs, elem, depth)
 	}
-	sort.Strings(fields)
-	return "{" + strings.Join(fields, ",") + "}"
+	out, err := json.Marshal(root)
+	if err != nil {
+		return "{}"
+	}
+	return string(out)
+}
+
+// insertPath places a value for one element at its path inside the tree being built,
+// creating the intermediate backbone objects as it goes.
+func insertPath(reg *registry.Registry, node map[string]any, segs []string, elem *registry.ElementDefinition, depth int) {
+	typeCode := elem.Type[0].Code
+
+	for i, seg := range segs {
+		last := i == len(segs)-1
+		name := seg
+		if last && strings.HasSuffix(seg, "[x]") {
+			name = strings.TrimSuffix(seg, "[x]") + strings.ToUpper(typeCode[:1]) + typeCode[1:]
+		}
+		if name == "id" || name == "extension" || name == "modifierExtension" {
+			return
+		}
+
+		if last {
+			if _, exists := node[name]; exists {
+				return
+			}
+			raw := syntheticValue(reg, typeCode, depth)
+			if raw == "" {
+				return
+			}
+			var v any
+			if json.Unmarshal([]byte(raw), &v) != nil {
+				return
+			}
+			if elem.Max == "*" {
+				v = []any{v}
+			}
+			node[name] = v
+			return
+		}
+
+		// Intermediate segment: descend, creating the container if needed. Arrays keep a
+		// single element, which is all a constraint context needs.
+		child, ok := node[name]
+		if !ok {
+			child = map[string]any{}
+			node[name] = child
+		}
+		if arr, isArr := child.([]any); isArr {
+			if len(arr) == 0 {
+				return
+			}
+			child = arr[0]
+		}
+		m, ok := child.(map[string]any)
+		if !ok {
+			return
+		}
+		node = m
+	}
 }
 
 // syntheticValue renders a value for one type code, using the registry to tell primitives
@@ -137,6 +183,9 @@ func syntheticValue(reg *registry.Registry, typeCode string, depth int) string {
 			return ""
 		}
 		return syntheticInstance(reg, typeSD, depth-1)
+	}
+	if typeSD != nil && typeSD.Kind == "resource" {
+		return ""
 	}
 	// Primitives: the JSON form follows the primitive's own base type in the SD.
 	base := typeCode
@@ -172,7 +221,7 @@ func syntheticValue(reg *registry.Registry, typeCode string, depth int) string {
 // evaluates against that element's value.
 //
 // Returns false when the sub-element is absent from the synthetic instance, in which case the
-// caller keeps the full instance rather than inventing a context.
+// caller skips the constraint rather than evaluating it against the wrong node.
 func contextFor(e constraintEntry, shape string) (string, bool) {
 	rest := strings.TrimPrefix(e.path, e.sd+".")
 	if rest == e.path || rest == "" {
@@ -187,7 +236,6 @@ func contextFor(e constraintEntry, shape string) (string, bool) {
 		if !ok {
 			return "", false
 		}
-		// Choice elements are stored under their concrete name in the instance.
 		v, ok := m[seg]
 		if !ok && strings.HasSuffix(seg, "[x]") {
 			base := strings.TrimSuffix(seg, "[x]")

--- a/pkg/constraint/enginegaps_test.go
+++ b/pkg/constraint/enginegaps_test.go
@@ -1,6 +1,7 @@
 package constraint_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -166,6 +167,55 @@ func syntheticValue(reg *registry.Registry, typeCode string, depth int) string {
 	}
 }
 
+// contextFor narrows a type's instance to the node a constraint is declared on. A constraint
+// on the type's root element evaluates against the whole instance; one on a sub-element
+// evaluates against that element's value.
+//
+// Returns false when the sub-element is absent from the synthetic instance, in which case the
+// caller keeps the full instance rather than inventing a context.
+func contextFor(e constraintEntry, shape string) (string, bool) {
+	rest := strings.TrimPrefix(e.path, e.sd+".")
+	if rest == e.path || rest == "" {
+		return "", false // declared on the root element
+	}
+	var node any
+	if err := json.Unmarshal([]byte(shape), &node); err != nil {
+		return "", false
+	}
+	for _, seg := range strings.Split(rest, ".") {
+		m, ok := node.(map[string]any)
+		if !ok {
+			return "", false
+		}
+		// Choice elements are stored under their concrete name in the instance.
+		v, ok := m[seg]
+		if !ok && strings.HasSuffix(seg, "[x]") {
+			base := strings.TrimSuffix(seg, "[x]")
+			for k, kv := range m {
+				if strings.HasPrefix(k, base) && len(k) > len(base) {
+					v, ok = kv, true
+					break
+				}
+			}
+		}
+		if !ok {
+			return "", false
+		}
+		if arr, isArr := v.([]any); isArr {
+			if len(arr) == 0 {
+				return "", false
+			}
+			v = arr[0]
+		}
+		node = v
+	}
+	out, err := json.Marshal(node)
+	if err != nil {
+		return "", false
+	}
+	return string(out), true
+}
+
 // TestAuditEngineExpressionGaps compiles and evaluates every published constraint expression
 // against instances built from the SDs, and groups whatever the engine cannot handle.
 func TestAuditEngineExpressionGaps(t *testing.T) {
@@ -176,9 +226,8 @@ func TestAuditEngineExpressionGaps(t *testing.T) {
 	entries := collectConstraints(reg)
 	t.Logf("distinct published constraints: %d", len(entries))
 
-	// One instance per type that declares constraints, built from that type's own SD, plus
-	// the empty object so expressions that need no operands are still exercised.
-	shapes := map[string]string{"empty": "{}"}
+	// One instance per type that declares constraints, built from that type's own SD.
+	shapes := map[string]string{}
 	for _, e := range entries {
 		if _, ok := shapes[e.sd]; ok {
 			continue
@@ -187,11 +236,12 @@ func TestAuditEngineExpressionGaps(t *testing.T) {
 			shapes[e.sd] = syntheticInstance(reg, sd, 2)
 		}
 	}
-	t.Logf("synthetic instances built from SDs: %d", len(shapes)-1)
+	t.Logf("synthetic instances built from SDs: %d", len(shapes))
 
 	type failure struct{ key, sd, path, shape, expr, err string }
 	var compileFails, evalFails []failure
 	seen := map[string]bool{}
+	skippedNoContext := 0
 
 	for _, e := range entries {
 		expr, cerr := fhirpath.Compile(e.expr)
@@ -206,10 +256,31 @@ func TestAuditEngineExpressionGaps(t *testing.T) {
 		// types it raises a TypeError instead, so a Timing constraint evaluated against a
 		// Patient reports "expected a String, got HumanName" — a fact about the audit, not
 		// about the engine. Reporting those upstream would waste the maintainers' time.
-		for _, shapeName := range []string{e.sd, "empty"} {
+		// Its own type only. The empty object was here to exercise expressions needing no
+		// operands, but `{}` is itself a node: exists() returns true and a function expecting a
+		// primitive receives an object, which reports a type mismatch that is an artifact of
+		// the audit. The type's own instance already exercises those expressions.
+		for _, shapeName := range []string{e.sd} {
 			shape, ok := shapes[shapeName]
 			if !ok {
 				continue
+			}
+			// A constraint is evaluated with the node it is declared on as context. For one
+			// declared on a sub-element — cnl-1 on EvidenceVariable.url — that is the element's
+			// value, not the resource, and evaluating it against the resource reports a type
+			// mismatch that says nothing about the engine.
+			//
+			// When the context cannot be built — the synthetic instance does not model backbone
+			// elements, so Measure.group.linkId has nowhere to point — the constraint is skipped
+			// rather than evaluated against the wrong node. Skipping is counted and reported, so
+			// the coverage gap stays visible instead of passing for a clean result.
+			if strings.Contains(strings.TrimPrefix(e.path, e.sd+"."), ".") || e.path != e.sd {
+				ctxShape, ok := contextFor(e, shape)
+				if !ok {
+					skippedNoContext++
+					continue
+				}
+				shape = ctxShape
 			}
 			ctx := eval.NewContext([]byte(shape))
 			if _, eerr := expr.EvaluateWithContext(ctx); eerr != nil {
@@ -223,6 +294,9 @@ func TestAuditEngineExpressionGaps(t *testing.T) {
 		}
 	}
 
+	if skippedNoContext > 0 {
+		t.Logf("=== skipped, declared context not representable in a synthetic instance: %d", skippedNoContext)
+	}
 	t.Logf("=== compile failures: %d", len(compileFails))
 	for _, f := range compileFails {
 		t.Logf("  [%s] %s.%s: %s", f.key, f.sd, f.path, f.err)


### PR DESCRIPTION
v1.6.0 fixes the `substring` panic. **Five of the six findings reported so far are closed**; `matches()` remains open.

| # | Finding | Status |
| --- | --- | --- |
| 1 | Type-name shadowing (`ref-1`) | fixed v1.4.0 |
| 2 | `%ucum` undefined (5 constraints) | fixed v1.5.1 |
| 3 | ReDoS guard misidentifies quantifiers (`eld-19`/`eld-20`) | fixed v1.5.2 |
| 4 | `Quantity` comparison (`rng-2`) | fixed v1.5.1 |
| 5 | `substring()` panics on negative length | **fixed v1.6.0** |
| 6 | `matches()` searches instead of testing the whole string | **open** |

## The consequence beyond the crash itself

**R5 can be audited to completion for the first time.** The panic used to cut the sweep short, so the earlier R5 numbers were not results — they were a run that stopped partway.

| Version | Constraints | Skipped | Compile failures | Evaluation failures |
| --- | --- | --- | --- | --- |
| R4 4.0.1 | 252 | 5 | 0 | 0 |
| R4B 4.3.0 | 256 | 8 | 0 | 2 |
| R5 5.0.0 | 330 | 6 | 1 | 0 |

And **every remaining failure belongs to the published specification, not the engine** — which closes the two items I had recorded as unverified rather than leaving them hanging.

## `sdf-24`/`sdf-25` in R4B are HL7's — and HL7 proved it

They compute `id.substring(0, $this.length()-10)`. Inside that `where`, `$this` is the element — an object — so `.length()` is a type error and the engine is right to report it.

HL7 corrected it in R5, which is what settles the attribution:

```
R4B:  id.substring(0, $this.length()-10)
R5:   path.substring(0, $this.path.length()-…)     navigates to path first
```

## `eld-11` in R5 is also HL7's

`type.code.contains(":")` uses a double-quoted literal. FHIRPath states *"String literals are surrounded by single-quotes"*, so rejecting it is correct. HL7's own validator tolerates it.

## One inconsistency left in the substring fix

Reportable but with no practical impact:

```
'abc'.substring(0, -1)           => ""      a one-item collection
'abc'.substring(-1, 2)           => {}      empty
'abc'.substring(0, -1).exists()  => true    would be false with {}
'abc'.substring(10, 2).exists()  => false
```

A negative length returns a collection holding the empty string while an out-of-range start returns an empty collection. Constraints branch on `exists()`, so the distinction matters — but the only constraints reaching a negative length are the defective R4B pair.

Full suite and `golangci-lint` clean.