### PR TITLE
docs: withdraw the matches() finding — the engine was right, the invariants are not

### DIFF
--- a/docs/VALIDATION-GAPS.md
+++ b/docs/VALIDATION-GAPS.md
@@ -215,6 +215,39 @@ Worth noting that the reference is not self-consistent here: an unresolvable **C
 warning there, an unresolvable **extension** an error, though in both cases the validator merely
 lacks a definition. We treat both as warnings.
 
+### Unanchored `matches()` in FHIR's own invariants: we evaluate as published, HL7 anchors
+
+FHIRPath defines two functions: `matches(regex)` is true when the pattern is found **within** the
+value, `matchesFull(regex)` when it matches the **entire** value. The official conformance suite
+fixes this, in both the R4 and R5 corpora, with HL7's own test names carrying the distinction:
+
+```text
+testMatchesWithinUrl2      '…/FHIR-ModelInfo|4.0.1'.matches('Library')      => true
+testMatchesFullWithinUrl3  same value and pattern, .matchesFull('Library')  => false
+```
+
+FHIR's published invariants are written as though `matches()` were anchored, so many are weaker
+than their authors intended: **32 of 37** patterns in the R4 corpus are unanchored, including
+`eld-19`, `eld-20`, and the `[A-Z]([A-Za-z0-9_]){0,254}` identifier constraint shared by 30
+canonical resources. A `StructureDefinition` declaring
+`"path": "Patient has spaces, and #bad chars!"` satisfies `eld-19`, because `Patient` is found
+within it.
+
+**We evaluate the invariants as published.** That is the specification-correct reading, and it
+follows this project's first principle — everything comes from the StructureDefinition, and
+rewriting a published constraint to mean something else is the same class of move as hardcoding
+one.
+
+The consequence is a divergence from HL7's validator, which anchors and reports `eld-19` as an
+error. Worth being precise about who departs from what: anchoring makes HL7's validator fail a
+conformance case whose expected value the suite fixes. The defect is in the constraints, and
+belongs upstream with FHIR core.
+
+If a deployment needs to match the reference on these invariants before HL7 corrects them, the
+change is a single substitution of `matchesFull` for `matches` in published expressions. It is
+deliberately not implemented here, and would have to be recorded as a deviation rather than
+presented as the language's behaviour.
+
 ### Example URLs in canonical positions: we say nothing, HL7 errors
 
 HL7 additionally reports `Error @ Patient.extension[0].url — Example URLs are not allowed in this

--- a/docs/VALIDATION-GAPS.md
+++ b/docs/VALIDATION-GAPS.md
@@ -330,14 +330,21 @@ What remains is ergonomics, neither of which changes a verdict:
 Open only if evidence appears:
   GO-GAP-005: Issue deduplication - no real duplicate found yet
 
-Blocked upstream in gofhir/fhirpath (2 constraints, see
-docs/plans/2026-07-30-fhirpath-engine-gaps.md):
-  eld-19 eld-20                      published FHIR regex rejected as dangerous
-
-Fixed upstream, now evaluating correctly:
+Nothing is blocked in gofhir/fhirpath any more. Every engine finding is closed
+(see docs/plans/2026-07-30-fhirpath-engine-gaps.md):
   ref-1                              type-name shadowing        (fhirpath v1.4.0)
   age-1 cnt-3 dis-1 drt-1 ras-1      %ucum undefined            (fhirpath v1.5.1)
   rng-2                              Quantity comparison        (fhirpath v1.5.1)
+  eld-19 eld-20                      ReDoS guard false positive (fhirpath v1.5.2)
+  R5 sdf-24 sdf-25                   substring panic            (fhirpath v1.6.0)
+
+Awaiting HL7, not the engine:
+  eld-19 eld-20 + 30 canonical *-0   invariants use matches() where they meant matchesFull(),
+                                     so they pass on any value containing an acceptable
+                                     substring. A defect in the published constraints; we
+                                     evaluate them as written. To be co-filed against FHIR core.
+  R4B sdf-24 sdf-25                  $this.length() on an object; HL7 fixed it in R5
+  R5 eld-11                          double-quoted string literal, invalid in FHIRPath
 ```
 
 Done: GO-GAP-001 (`compose.exclude`), GO-GAP-002 (filter operators) and version-aware

--- a/docs/plans/2026-07-30-fhirpath-engine-gaps.md
+++ b/docs/plans/2026-07-30-fhirpath-engine-gaps.md
@@ -16,7 +16,7 @@ With that fixed, these constraints are reached for the first time.
 
 ## Status as of v1.6.0
 
-Six findings so far, five closed.
+Six findings so far: five closed, one withdrawn as our own error. No engine defect is open.
 
 | # | Finding | Constraints | Status |
 | --- | --- | --- | --- |
@@ -25,7 +25,7 @@ Six findings so far, five closed.
 | 3 | ReDoS guard misidentifies quantifiers | `eld-19` `eld-20` | fixed in v1.5.2 |
 | 4 | `Quantity` comparison | `rng-2` | fixed in v1.5.1 |
 | 5 | `substring()` panics on negative length | R5 `sdf-24` `sdf-25` | **fixed in v1.6.0** (see note) |
-| 6 | `matches()` searches instead of testing the whole string | 32 of 37 R4 patterns | **open** |
+| 6 | `matches()` unanchored | — | **withdrawn — our error; the defect is in FHIR's invariants** |
 
 With the panic gone, R5 can be audited to completion for the first time — the crash used to cut
 the sweep short, so its earlier "results" were not results at all.
@@ -39,23 +39,25 @@ the sweep short, so its earlier "results" were not results at all.
 Every remaining failure across the three versions belongs to the published specification rather
 than to the engine.
 
-### Note on the v1.6.0 substring fix
+### Note on the v1.6.0 substring fix — resolved, they were right
 
-The panic is gone, but the return value is inconsistent with the sibling cases: a negative
-length yields a collection holding the empty string, where an out-of-range start yields an empty
-collection.
+We reported the return value as inconsistent, comparing `substring(0, -1)` to `substring(-1, 2)`.
+That was the wrong sibling. The specification treats the two arguments differently on purpose:
 
 ```text
-'abc'.substring(0, -1)           => ""      a one-item collection
-'abc'.substring(-1, 2)           => {}      empty
-'abc'.substring(10, 2)           => {}      empty
-'abc'.substring(0, -1).exists()  => true    would be false with {}
-'abc'.substring(10, 2).exists()  => false
+'abc'.substring(-1, 2)      { }    an out-of-range start returns empty       — stated explicitly
+'abc'.substring(10, 2)      { }    same
+'abc'.substring(1, 1000)    'bc'   an over-long length is clamped, not empty — stated explicitly
+'abc'.substring(0, -1)      ''     a negative length clamps to zero
+'abc'.substring(0, 0)       ''     which is what zero already gave
 ```
 
-Practical impact today is nil — the only constraints reaching a negative length are R4B's
-`sdf-24`/`sdf-25`, which are themselves defective — but it is worth mentioning upstream for
-consistency, since constraints branch on `exists()`.
+Length is never named as a cause of empty; start is. A negative length is the same clamping rule
+at the other end, so `''` is right. Verified all five against v1.6.0; `fhirpath.js` 5.1.0 agrees.
+
+The `exists()` caveat we raised was real and is now documented upstream: an empty string is a
+value, so `substring(0, -1).exists()` is `true`, and a constraint meaning to ask whether any
+characters came back wants `.length() > 0`.
 
 ### Two remaining failures that are HL7's, not the engine's
 
@@ -109,288 +111,57 @@ R4 and R4B are **not** exposed: their only `substring` use is `ref-1`'s single-a
 and `''.substring(1)` both return `{}`. Confirmed end to end that a Patient with
 `"reference": "#"` validates normally rather than crashing.
 
-## Finding 6: `matches()` searches instead of testing the whole string — OPEN
+## Finding 6: `matches()` — WITHDRAWN, the engine is correct
 
-Not caught by the audit, which only asks whether an expression evaluates without error. Found by
-checking `eld-19` end to end after v1.5.2 made it evaluable: it evaluates, and returns the wrong
-answer.
+This was our error, and the correction is worth recording because the reasoning that produced it
+looks sound until you check the specification properly.
 
-```text
-'abc def'.matches('abc')      => true    expected false
-'xabcx'.matches('abc')        => true    expected false
-'abc'.matches('abc')          => true    correct
-```
+We reported that `matches()` should test the whole string. FHIRPath defines **two** functions with
+deliberately opposite semantics, and `matches()` is the unanchored one:
 
-A partial match makes every validation regex vacuous: any string containing an acceptable
-substring passes. `eld-19` is the case in hand — a `path` of `"Patient has spaces, and #bad
-chars!"` passes, because `Patient` matches the leading character class, where the reference
-reports an error.
-
-Anchored patterns are unaffected, which is why R5's `cnl-1` (`matches('^[^|# ]+$')`) behaves
-correctly — verified returning `false` for a URL containing a pipe.
-
-The specification is not explicit here. It says only *"Returns `true` when the value matches the
-given regular expression"*, without stating whether the whole input is tested. The case for
-anchoring is that the reference implementation behaves that way — HL7's validator reports
-`eld-19` on the path above — and that the alternative empties every regex constraint of meaning.
-Roughly 37 constraints in the R4 corpus use `matches()`.
-
-## R5 `eld-11` does not compile — and that one is HL7's
-
-```text
-lexer errors: token recognition error at: '"' ':' '"'
-eld-11: ... or type.code.contains(":") or ...
-```
-
-The literal is double-quoted. FHIRPath states *"String literals are surrounded by
-single-quotes"*, so `":"` is not a string literal and the engine is right to reject it. This is a
-defect in the published R5 StructureDefinition rather than in the engine, and belongs upstream
-with HL7. Worth knowing that HL7's own validator tolerates it.
-
-## How this was measured## How this was measured
-
-`pkg/constraint/enginegaps_test.go` (run with `FPAUDIT=1`) derives everything from the
-StructureDefinitions in the loaded packages — nothing is enumerated by hand, so it stays
-correct across FHIR versions and package sets:
-
-- expressions come from `ElementDefinition.constraint` across all 910 SDs
-- the instances they are evaluated against are built from `ElementDefinition.type`
-- shadowing candidates are found by comparing each element's name against the type
-  containing it
-
-`FPAUDIT_VERSION=4.3.0` or `5.0.0` re-runs it against R4B or R5.
-
-Two limits worth stating, both learned by getting them wrong:
-
-- Each expression is evaluated **only** against an instance of its own type, and with the node it
-  is declared on as context. Cross-evaluating shapes reported type mismatches that were facts
-  about the audit, not the engine — a Timing constraint against a Patient, `matches()` against
-  the empty object.
-- Where the declared context cannot be built, the constraint is **skipped and counted** rather
-  than evaluated against the wrong node. Instances are now built by walking the full snapshot by
-  path rather than only direct children, which models backbone elements — `Measure.group.linkId`
-  is defined in Measure's snapshot, not in any separate SD. That took skipping from 30 of 252 to
-  **5** in R4 and from 58 of 330 to **6** in R4B. The remainder are unaudited, not clean.
-
-## Summary
-
-| # | Gap | Constraints affected | Severity |
-| --- | --- | --- | --- |
-| 1 | An element whose name matches its containing type returns the container | `ref-1` | **critical — silent false pass** |
-| 2 | `%ucum` is undefined | `age-1` `cnt-3` `dis-1` `drt-1` `ras-1` | high |
-| 3 | A published FHIR regex is rejected as dangerous | `eld-19` `eld-20` | medium |
-| 4 | Two `Quantity` values cannot be compared | `rng-2` | medium |
-
----
-
-## 1. An element whose name matches its containing type returns the container — FIXED in v1.4.0
-
-Kept for the record; the behaviour below is v1.1.0's.
-
-The engine infers a node's FHIR type from its shape, then treats an identifier matching that
-type name — **case-insensitively, in any position** — as a reference to the node itself
-instead of navigating to a field of that name.
-
-In FHIRPath, resolving the type name to the node is correct only for the **capitalised** type
-at the **start** of an expression (`Patient.name`). Applied case-insensitively and at any
-position, the type name shadows any element of the same name.
-
-```go
-ctx := eval.NewContext([]byte(`{"reference":"#nope"}`))
-expr, _ := fhirpath.Compile(`reference`)
-// got  == [{"reference":"#nope"}]     <- the container
-// want == ["#nope"]                   <- the element's value
-```
-
-Every string function then operates on the container's JSON:
-
-| Expression on `{"reference":"#nope"}` | Got | Want |
-| --- | --- | --- |
-| `reference` | `{"reference":"#nope"}` | `"#nope"` |
-| `reference.startsWith('#')` | `false` | `true` |
-| `reference.substring(1)` | `"reference":"#nope"}` | `"nope"` |
-| `reference.length()` | `21` | `5` |
-| `reference = '#nope'` | `false` | `true` |
-
-`substring(1)` returning `"reference":"#nope"}` is the giveaway — the container minus its
-first character.
-
-**It is the type name, not that name in particular.** The same shadowing happens for other
-inferred types, and does not happen when the shape does not infer one:
-
-```
-{"start":"2026-01-01","end":"2020-01-01"}  ->  period    => the container   (inferred Period)
-{"start":"2026-01-01","end":"2020-01-01"}  ->  Period    => the container   correct
-{"value":5,"code":"mg","system":"..."}     ->  quantity  => the container   (inferred Quantity)
-{"display":"d"}                            ->  reference => {}              correct
-{"foo":"bar"}                              ->  period    => {}              correct
-```
-
-### Scope, measured rather than guessed
-
-Scanning every complex type for elements whose own name matches the type containing them
-yields **exactly three in R4**, of which **one is shadowed**:
-
-| Element | Result |
+| Function | Semantics |
 | --- | --- |
-| `Reference.reference` | **shadowed** |
-| `Extension.extension` | navigates correctly |
-| `Expression.expression` | navigates correctly |
+| `matches(regex)` | true when the pattern is found **within** the value |
+| `matchesFull(regex)` | true when the pattern matches the **entire** value |
 
-We checked specifically that `ext-1` (`extension.exists() != value.exists()`) is **not**
-affected, and that `tim-5` evaluates correctly against real `Timing.repeat` data — the two
-places we expected collateral damage and did not find it.
+The official conformance suite settles it, in both the R4 and R5 corpora, with two groups over one
+input — and HL7's own test names carry the word:
 
-### What it breaks
-
-`ref-1` on the `Reference` type, `SHALL`-level:
-
-```
-ref-1: SHALL have a contained resource if a local reference is provided
-  reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))
-```
-
-`startsWith('#')` returns `false`, so `.not()` returns `true`, so the disjunction
-short-circuits `true` and **`ref-1` can never fail** — on every `Reference` in every
-resource. Confirmed end to end: `Patient.managingOrganization` of `#nope` with no matching
-contained resource is a `ref-1` failure in HL7 and passes for us.
-
-This is worse than an error: no diagnostic says the check did not happen. Sweeping the
-official example corpus makes it visible through the constraint's own `trace()`, which prints
-the container instead of the id, thousands of times:
-
-```text
-[trace] url: ["\"reference\":\"Patient/example\"}"]
-[trace] url: ["\"display\":\"Dr Adam Careful\",\"reference\":\"Practitioner/example\"}"]
-```
-
-Each of those should have been a bare id.
-
----
-
-## 2. `%ucum` is undefined — FIXED in v1.5.1
-
-Kept for the record; the behaviour below is v1.1.0's.
-
-```
-InvalidPathError: undefined variable: %ucum
-```
-
-`%ucum` is an environment constant the FHIR specification defines for FHIRPath
-(`http://unitsofmeasure.org`), alongside `%resource` / `%rootResource` / `%context`. We wire
-those three explicitly, but `%ucum` is a fixed constant with no caller input, so it belongs
-with the engine's FHIR context rather than being injected per call by every consumer.
-
-Five `SHALL`-level invariants depend on it:
-
-| Key | Type | Fragment |
+| Case | Expression | Expected |
 | --- | --- | --- |
-| `age-1` | Age | `(system.empty() or system = %ucum)` |
-| `drt-1` | Duration | `code.exists() implies ((system = %ucum) and value.exists())` |
-| `cnt-3` | Count | `(system.empty() or system = %ucum)` |
-| `dis-1` | Distance | `(system.empty() or system = %ucum)` |
-| `ras-1` | RiskAssessment.prediction.probability[x] | `low.system = %ucum` |
+| `testMatchesWithinUrl2` | `'http://…/FHIR-ModelInfo|4.0.1'.matches('Library')` | `true` |
+| `testMatchesFullWithinUrl3` | same value and pattern, `.matchesFull('Library')` | `false` |
 
-Confirmed end to end: a `Condition.onsetAge` whose `system` is not UCUM is an `age-1` error
-in HL7, and an unevaluatable-constraint warning for us.
+Verified against v1.6.0: `matches` returns `true`, `matchesFull` returns `false`, and
+`matchesFull` anchors as expected (`'  X  '` against the identifier pattern is `false`).
+`fhirpath.js` 5.1.0 agrees. Anchoring `matches()` would fail a case the suite fixes the value of.
 
----
+Our mistake was assuming a single function and reading the specification as ambiguous. It is not
+ambiguous — we had read half of it.
 
-## 3. A published FHIR regex is rejected as dangerous
+### The real defect is in FHIR's published invariants, and it is HL7's
 
-```
-InvalidExpressionError: potentially dangerous regex: consecutive quantifiers
-```
+The underlying observation survives, and is a better finding than the one we filed. FHIR's
+invariants are written as though `matches()` were anchored, so under spec-correct evaluation many
+are weaker than their authors intended:
 
-Affects `eld-19` and `eld-20` on `ElementDefinition`, whose patterns are published by HL7 in
-the R4 specification itself:
+- **32 of 37** `matches()` patterns in the R4 corpus are unanchored
+- including `eld-19`, `eld-20`, and the `[A-Z]([A-Za-z0-9_]){0,254}` identifier constraint shared
+  by 30 canonical resources
+- concrete false pass: a `StructureDefinition` whose differential declares
+  `"path": "Patient has spaces, and #bad chars!"` satisfies `eld-19`, because `Patient` is found
+  within it
 
-```
-eld-19: path.matches('[^\s\.,:;\'"\/|?!@#$%&*()\[\]{}]{1,64}(\.[^\s\.,:;\'"\/|?!@#$%&*()\[\]{}]{1,64}(\[x\])?(\:[^\s\.]+)?)*')
-```
+Those constraints should use `matchesFull()` or anchor with `^…$`. R5's `cnl-1` already anchors,
+which shows HL7 knows the difference where they have thought about it.
 
-The ReDoS guard is a good idea, but here it rejects a pattern that ships with the
-specification, so `ElementDefinition.path` cannot be validated at all — which matters for
-anyone validating StructureDefinitions, profiles or IG content.
+To be filed against FHIR core rather than the engine. The engine maintainers offered to co-file,
+contributing specification citations, suite case references and `fhirpath.js` verification.
 
-Confirmed end to end on a StructureDefinition whose differential declares
-`"path": "Patient has spaces, and #bad chars!"`:
+### Consequence for us
 
-```text
-HL7:    Error   @ StructureDefinition.differential.element[1]
-                  Constraint failed: eld-19: 'Element names cannot include some special characters'
-        Warning @ StructureDefinition.differential.element[1]
-                  Constraint failed: eld-20: 'Element names should be simple alphanumerics ...'
+Evaluating the invariants as published is the specification-correct behaviour, and it is what we
+do. It also means we diverge from HL7's validator, which anchors — and which therefore does not
+satisfy `testMatchesWithinUrl2`. Recorded as a deliberate divergence in
+`docs/VALIDATION-GAPS.md`; we do not rewrite published constraints.
 
-ours:   Warning @ StructureDefinition.differential.element[1]
-                  Could not evaluate constraint 'eld-19': potentially dangerous regex
-        Warning @ StructureDefinition.differential.element[1]
-                  Could not evaluate constraint 'eld-20': potentially dangerous regex
-```
-
-The `SHALL`-level `eld-19` never produces a verdict, so a malformed element path passes.
-
-Worth considering: Go's `regexp` is RE2, which has no catastrophic backtracking, so the
-consecutive-quantifier heuristic may be guarding against a risk the underlying engine does
-not carry. If the guard is needed for a non-RE2 path, an allowance for patterns coming from
-loaded StructureDefinitions would keep the specification's own regexes working.
-
----
-
-## 4. Two `Quantity` values cannot be compared — FIXED in v1.5.1
-
-Kept for the record; the behaviour below is v1.1.0's.
-
-```
-InvalidOperationError: cannot apply 'compare' to Quantity and Quantity
-```
-
-Breaks `rng-2` on `Range`, `SHALL`-level:
-
-```
-rng-2: If present, low SHALL have a lower value than high
-  low.empty() or high.empty() or (low <= high)
-```
-
-`Range.low` and `Range.high` are `SimpleQuantity`, so this comparison is the entire point of
-the invariant. Confirmed end to end on
-`MedicationRequest.dosageInstruction[0].doseAndRate[0].doseRange` with `low` 10 mg and `high`
-2 mg: HL7 reports `rng-2`, we report that we could not evaluate it.
-
-This one has real depth — comparing quantities properly means comparing commensurable units,
-so `10 mg <= 2 g` should hold, which is `gofhir/ucum` territory. Comparing `value` only when
-`code` and `system` match, and returning empty otherwise, would already make `rng-2`
-decidable in the common case without claiming unit conversion.
-
----
-
-## What remains
-
-Only the regex guard, affecting `eld-19` and `eld-20`. It blocks a pattern the specification
-itself publishes, so `ElementDefinition.path` cannot be validated and a malformed path passes.
-
-Go's `regexp` is RE2, which has no catastrophic backtracking, so the consecutive-quantifier
-heuristic may be guarding a risk this engine does not carry. If the guard is needed for a
-non-RE2 path, an allowance for patterns coming from loaded StructureDefinitions would keep the
-specification's own regexes working.
-
-## `gofhir/ucum` — audited, no defects found
-
-Worth recording since it was checked at the same time. Thirty UCUM codes through
-`pkg/ucumvalidator`, compared against HL7:
-
-- 20 valid codes accepted, including `mm[Hg]`, `10*3/uL`, `{beats}/min`, `k[IU]/L`, `g/(24.h)`
-- 8 invalid codes rejected: `mmHg`, `degF`, `foo`, `mg/`, `mg dL`, `[bogus]`, `mg**2`, `//min`
-- **Two of our own expectations were wrong, not the library**: `10^3/uL` and `MG` are valid
-  (UCUM defines `10^` alongside `10*`, and `G` is gauss, so `MG` is megagauss). The library
-  and HL7 both accept them; only our test expectation was mistaken.
-
-One divergence, where the library appears **more correct than the reference**: `//min` is
-rejected by us and accepted by HL7. The UCUM grammar allows a leading solidus (`/min`) but
-not two, and the library's message names the position precisely (`unexpected token "/"
-(solidus)`). No change requested.
-
-Separately, this audit turned up something of ours rather than the library's: an invalid UCUM
-code is a **warning** for us and an **error** in HL7. Since `system` is
-`http://unitsofmeasure.org` and the code does not exist in it, this is the same rule we made
-an error in #70 — a code absent from the CodeSystem the instance names. Tracked on our side.


### PR DESCRIPTION
The fhirpath maintainers answered with the conformance suite, and **they are correct**. Recording the correction, because the reasoning that produced my error looks sound until you check the specification properly.

## What I got wrong

FHIRPath defines **two** functions with deliberately opposite semantics:

| Function | Semantics |
| --- | --- |
| `matches(regex)` | true when the pattern is found **within** the value |
| `matchesFull(regex)` | true when the pattern matches the **entire** value |

The official suite fixes this in both the R4 and R5 corpora, and HL7's own test names carry the word:

```
testMatchesWithinUrl2      '…/FHIR-ModelInfo|4.0.1'.matches('Library')      => true
testMatchesFullWithinUrl3  same value and pattern, .matchesFull('Library')  => false
```

Verified every claim against v1.6.0 rather than taking it on faith:

| Claim | Verified |
| --- | --- |
| `matchesFull()` exists in the engine | yes — `funcs/strings.go:55` |
| `matches('Library')` → `true` | yes |
| `matchesFull('Library')` → `false` | yes |
| `matchesFull` anchors: `'  X  '` → `false` | yes |
| `substring(1, 1000)` → `bc` (clamped, not empty) | yes |
| `substring(0, 0)` → `""` | yes |

**My mistake was assuming a single function and reading the spec as ambiguous.** It is not ambiguous — I had read half of it. Anchoring `matches()` would fail a case whose expected value the suite fixes.

## The substring note is withdrawn too

Same kind of error: I compared `substring(0, -1)` to `substring(-1, 2)`, and the right sibling is `substring(1, 1000)`. The specification treats the two arguments differently **on purpose** — an out-of-range start returns empty and says so, while an over-long length is *clamped*. A negative length clamping to `''` is that same rule at the other end, and `substring(0, 0)` already returned `''`.

The `exists()` caveat I raised was real and is now documented upstream.

## What survives — and it is HL7's

FHIR's invariants are written as though `matches()` were anchored, so under spec-correct evaluation many are weaker than their authors intended:

- **32 of 37** `matches()` patterns in the R4 corpus are unanchored
- including `eld-19`, `eld-20`, and the `[A-Z]([A-Za-z0-9_]){0,254}` identifier constraint shared by 30 canonical resources
- concrete false pass: a `StructureDefinition` declaring `"path": "Patient has spaces, and #bad chars!"` **satisfies** `eld-19`, because `Patient` is found within it

R5's `cnl-1` already anchors, so HL7 knows the difference where they have thought about it. To be filed against FHIR core; the engine maintainers offered to co-file with spec citations and suite references.

## Our position, unchanged in code

**We evaluate the invariants as published.** That is the specification-correct reading, and it follows this project's first principle: rewriting a published constraint to mean something else is the same class of move as hardcoding one.

The divergence from HL7's validator is recorded in [VALIDATION-GAPS.md](docs/VALIDATION-GAPS.md) alongside the others — with the precision that anchoring is what makes HL7's validator fail the suite case, so the reference is the one departing here.

Docs only. No behaviour change.